### PR TITLE
issue#24 - Bug fixes as listed below

### DIFF
--- a/logger/src/main/java/io/synclite/logger/Derby.java
+++ b/logger/src/main/java/io/synclite/logger/Derby.java
@@ -38,27 +38,27 @@ public final class Derby extends SyncLite {
     }
     
     
-	public static synchronized final void initialize(Path dbPath) throws SQLException {
+	public static final void initialize(Path dbPath) throws SQLException {
 		SyncLite.initialize(DeviceType.DERBY, dbPath);
 	}
 
-	public static synchronized final void initialize(Path dbPath, String deviceName) throws SQLException {
+	public static final void initialize(Path dbPath, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.DERBY, dbPath, deviceName);
 	}
 
-	public static synchronized final void initialize(Path dbPath, SyncLiteOptions options) throws SQLException {
+	public static final void initialize(Path dbPath, SyncLiteOptions options) throws SQLException {
 		SyncLite.initialize(DeviceType.DERBY, dbPath, options);
 	}
 
-	public static synchronized final void initialize(Path dbPath, SyncLiteOptions options, String deviceName) throws SQLException {
+	public static final void initialize(Path dbPath, SyncLiteOptions options, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.DERBY, dbPath, options, deviceName);
 	}
 
-	public static synchronized final void initialize(Path dbPath, Path propsPath) throws SQLException {
+	public static final void initialize(Path dbPath, Path propsPath) throws SQLException {
 		SyncLite.initialize(DeviceType.DERBY, dbPath, propsPath);
 	}
 
-	public static synchronized final void initialize(Path dbPath, Path propsPath, String deviceName) throws SQLException {
+	public static final void initialize(Path dbPath, Path propsPath, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.DERBY, dbPath, propsPath, deviceName);
 	}
 
@@ -69,23 +69,6 @@ public final class Derby extends SyncLite {
 
 	protected DBProcessor getDBProcessor() {
 		return new DerbyProcessor();
-	}
-
-	@Override
-	protected void validateLibs(Logger tracer) throws SQLException {
-		try {
-			Class.forName("org.sqlite.JDBC");
-		} catch (ClassNotFoundException e) {
-			tracer.error("Failed to load sqlite jdbc driver : " + e.getMessage());
-			throw new SQLException("Failed to load sqlite jdbc driver");
-		}    	
-
-		try {
-    		Class.forName("org.apache.derby.jdbc.EmbeddedDriver");
-		} catch (ClassNotFoundException e) {
-			tracer.error("Failed to load derby jdbc driver : " + e.getMessage());
-			throw new SQLException("Failed to load derby jdbc driver");
-		}    	
 	}
 
 	@Override

--- a/logger/src/main/java/io/synclite/logger/DerbyAppender.java
+++ b/logger/src/main/java/io/synclite/logger/DerbyAppender.java
@@ -42,27 +42,27 @@ public final class DerbyAppender extends SyncLite {
     	return new DerbyAppenderConnection(url, extractAddress(url, PREFIX), prop); 
     }
         
-	public static synchronized final void initialize(Path dbPath) throws SQLException {
+	public static final void initialize(Path dbPath) throws SQLException {
 		SyncLite.initialize(DeviceType.DERBY_APPENDER, dbPath);
 	}
 
-	public static synchronized final void initialize(Path dbPath, String deviceName) throws SQLException {
+	public static final void initialize(Path dbPath, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.DERBY_APPENDER, dbPath, deviceName);
 	}
 
-	public static synchronized final void initialize(Path dbPath, SyncLiteOptions options) throws SQLException {
+	public static final void initialize(Path dbPath, SyncLiteOptions options) throws SQLException {
 		SyncLite.initialize(DeviceType.DERBY_APPENDER, dbPath, options);
 	}
 
-	public static synchronized final void initialize(Path dbPath, SyncLiteOptions options, String deviceName) throws SQLException {
+	public static final void initialize(Path dbPath, SyncLiteOptions options, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.DERBY_APPENDER, dbPath, options, deviceName);
 	}
 
-	public static synchronized final void initialize(Path dbPath, Path propsPath) throws SQLException {
+	public static final void initialize(Path dbPath, Path propsPath) throws SQLException {
 		SyncLite.initialize(DeviceType.DERBY_APPENDER, dbPath, propsPath);
 	}
 
-	public static synchronized final void initialize(Path dbPath, Path propsPath, String deviceName) throws SQLException {
+	public static final void initialize(Path dbPath, Path propsPath, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.DERBY_APPENDER, dbPath, propsPath, deviceName);
 	}
     
@@ -74,23 +74,6 @@ public final class DerbyAppender extends SyncLite {
 	protected DBProcessor getDBProcessor() {
 		return new DerbyProcessor();
 	}	
-
-	@Override
-	protected void validateLibs(Logger tracer) throws SQLException {
-		try {
-			Class.forName("org.sqlite.JDBC");
-		} catch (ClassNotFoundException e) {
-			tracer.error("Failed to load sqlite jdbc driver : " + e.getMessage());
-			throw new SQLException("Failed to load sqlite jdbc driver");
-		}    	
-		
-		try {
-    		Class.forName("org.apache.derby.jdbc.EmbeddedDriver");
-		} catch (ClassNotFoundException e) {
-			tracer.error("Failed to load derby jdbc driver : " + e.getMessage());
-			throw new SQLException("Failed to load derby jdbc driver");
-		}    	
-	}
 
 	@Override
 	protected void setDeviceTypeInOptions(SyncLiteOptions options) throws SQLException {

--- a/logger/src/main/java/io/synclite/logger/DerbyAppenderConnection.java
+++ b/logger/src/main/java/io/synclite/logger/DerbyAppenderConnection.java
@@ -70,7 +70,6 @@ public class DerbyAppenderConnection extends MultiWriterDBAppenderConnection {
     @Override
     final protected void doInitConn() throws SQLException  {
     	try {
-    		Class.forName("org.apache.derby.jdbc.EmbeddedDriver");
     		this.derbyURL = "jdbc:derby:" + this.path.toString();
     		this.derbyConnection = DriverManager.getConnection(derbyURL, this.props);
     		connAutoCommit(false);

--- a/logger/src/main/java/io/synclite/logger/DerbyConnection.java
+++ b/logger/src/main/java/io/synclite/logger/DerbyConnection.java
@@ -70,7 +70,6 @@ public class DerbyConnection extends MultiWriterDBConnection {
     @Override
     final protected void doInitConn() throws SQLException  {
     	try {
-    		Class.forName("org.apache.derby.jdbc.EmbeddedDriver");
     		this.derbyURL = "jdbc:derby:" + this.path.toString();
     		this.derbyConnection = DriverManager.getConnection(derbyURL, this.props);
     		connAutoCommit(false);

--- a/logger/src/main/java/io/synclite/logger/DuckDB.java
+++ b/logger/src/main/java/io/synclite/logger/DuckDB.java
@@ -39,27 +39,27 @@ public final class DuckDB extends SyncLite {
     }
     
     
-	public static synchronized final void initialize(Path dbPath) throws SQLException {
+	public static final void initialize(Path dbPath) throws SQLException {
 		SyncLite.initialize(DeviceType.DUCKDB, dbPath);
 	}
 
-	public static synchronized final void initialize(Path dbPath, String deviceName) throws SQLException {
+	public static final void initialize(Path dbPath, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.DUCKDB, dbPath, deviceName);
 	}
 
-	public static synchronized final void initialize(Path dbPath, SyncLiteOptions options) throws SQLException {
+	public static final void initialize(Path dbPath, SyncLiteOptions options) throws SQLException {
 		SyncLite.initialize(DeviceType.DUCKDB, dbPath, options);
 	}
 
-	public static synchronized final void initialize(Path dbPath, SyncLiteOptions options, String deviceName) throws SQLException {
+	public static final void initialize(Path dbPath, SyncLiteOptions options, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.DUCKDB, dbPath, options, deviceName);
 	}
 
-	public static synchronized final void initialize(Path dbPath, Path propsPath) throws SQLException {
+	public static final void initialize(Path dbPath, Path propsPath) throws SQLException {
 		SyncLite.initialize(DeviceType.DUCKDB, dbPath, propsPath);
 	}
 
-	public static synchronized final void initialize(Path dbPath, Path propsPath, String deviceName) throws SQLException {
+	public static final void initialize(Path dbPath, Path propsPath, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.DUCKDB, dbPath, propsPath, deviceName);
 	}
     
@@ -70,23 +70,6 @@ public final class DuckDB extends SyncLite {
 
 	protected DBProcessor getDBProcessor() {
 		return new DuckDBProcessor();
-	}
-
-	@Override
-	protected void validateLibs(Logger tracer) throws SQLException {
-		try {
-			Class.forName("org.sqlite.JDBC");
-		} catch (ClassNotFoundException e) {
-			tracer.error("Failed to load sqlite jdbc driver : " + e.getMessage());
-			throw new SQLException("Failed to load sqlite jdbc driver");
-		}    	
-		
-		try {
-    		Class.forName("org.duckdb.DuckDBDriver");
-		} catch (ClassNotFoundException e) {
-			tracer.error("Failed to load DuckDB jdbc driver : " + e.getMessage());
-			throw new SQLException("Failed to load DuckDB jdbc driver");
-		}    	
 	}
 
 	@Override

--- a/logger/src/main/java/io/synclite/logger/DuckDBAppender.java
+++ b/logger/src/main/java/io/synclite/logger/DuckDBAppender.java
@@ -46,27 +46,27 @@ public final class DuckDBAppender extends SyncLite {
     }
     
     
-	public static synchronized final void initialize(Path dbPath) throws SQLException {
+	public static final void initialize(Path dbPath) throws SQLException {
 		SyncLite.initialize(DeviceType.DUCKDB_APPENDER, dbPath);
 	}
 
-	public static synchronized final void initialize(Path dbPath, String deviceName) throws SQLException {
+	public static final void initialize(Path dbPath, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.DUCKDB_APPENDER, dbPath, deviceName);
 	}
 
-	public static synchronized final void initialize(Path dbPath, SyncLiteOptions options) throws SQLException {
+	public static final void initialize(Path dbPath, SyncLiteOptions options) throws SQLException {
 		SyncLite.initialize(DeviceType.DUCKDB_APPENDER, dbPath, options);
 	}
 
-	public static synchronized final void initialize(Path dbPath, SyncLiteOptions options, String deviceName) throws SQLException {
+	public static final void initialize(Path dbPath, SyncLiteOptions options, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.DUCKDB_APPENDER, dbPath, options, deviceName);
 	}
 
-	public static synchronized final void initialize(Path dbPath, Path propsPath) throws SQLException {
+	public static final void initialize(Path dbPath, Path propsPath) throws SQLException {
 		SyncLite.initialize(DeviceType.DUCKDB_APPENDER, dbPath, propsPath);
 	}
 
-	public static synchronized final void initialize(Path dbPath, Path propsPath, String deviceName) throws SQLException {
+	public static final void initialize(Path dbPath, Path propsPath, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.DUCKDB_APPENDER, dbPath, propsPath, deviceName);
 	}
     
@@ -78,23 +78,6 @@ public final class DuckDBAppender extends SyncLite {
 	protected DBProcessor getDBProcessor() {
 		return new DuckDBProcessor();
 	}	
-
-	@Override
-	protected void validateLibs(Logger tracer) throws SQLException {
-		try {
-			Class.forName("org.sqlite.JDBC");
-		} catch (ClassNotFoundException e) {
-			tracer.error("Failed to load sqlite jdbc driver : " + e.getMessage());
-			throw new SQLException("Failed to load sqlite jdbc driver");
-		}    	
-		
-		try {
-    		Class.forName("org.duckdb.DuckDBDriver");
-		} catch (ClassNotFoundException e) {
-			tracer.error("Failed to load DuckDB jdbc driver : " + e.getMessage());
-			throw new SQLException("Failed to load DuckDB jdbc driver");
-		}    	
-	}
 
 	@Override
 	protected void setDeviceTypeInOptions(SyncLiteOptions options) throws SQLException {

--- a/logger/src/main/java/io/synclite/logger/DuckDBAppenderConnection.java
+++ b/logger/src/main/java/io/synclite/logger/DuckDBAppenderConnection.java
@@ -67,7 +67,6 @@ public class DuckDBAppenderConnection extends MultiWriterDBAppenderConnection {
     @Override
     final protected void doInitConn() throws SQLException  {
     	try {
-    		Class.forName("org.duckdb.DuckDBDriver");
     		this.duckDBURL = "jdbc:duckdb:" + this.path.toString();
     		this.duckDBConnection = DriverManager.getConnection(duckDBURL, this.props);
     		connAutoCommit(false);

--- a/logger/src/main/java/io/synclite/logger/DuckDBConnection.java
+++ b/logger/src/main/java/io/synclite/logger/DuckDBConnection.java
@@ -67,7 +67,6 @@ public class DuckDBConnection extends MultiWriterDBConnection {
     @Override
     final protected void doInitConn() throws SQLException  {
     	try {
-    		Class.forName("org.duckdb.DuckDBDriver");
     		this.duckDBURL = "jdbc:duckdb:" + this.path.toString();
     		this.duckDBConnection = DriverManager.getConnection(duckDBURL, this.props);
     		connAutoCommit(false);

--- a/logger/src/main/java/io/synclite/logger/EventLogger.java
+++ b/logger/src/main/java/io/synclite/logger/EventLogger.java
@@ -80,12 +80,16 @@ public abstract class EventLogger extends SQLLogger {
 	}   
 
 	final void rollback(long commitId) throws SQLException {
-		rollbackLogSegment();
+		doRollback();
 		this.currentTxnLogCount = 0;
 		this.currentBatchLogCount = 0;
 		checkups();
 	}   
 	
+	protected void doRollback() throws SQLException {
+		rollbackLogSegment();
+	}
+
 	@Override
 	protected void initializeAdditionalMetadataProperties() throws SQLException {
 		String strVal = metadataMgr.getStringProperty("device_type");

--- a/logger/src/main/java/io/synclite/logger/H2.java
+++ b/logger/src/main/java/io/synclite/logger/H2.java
@@ -40,27 +40,27 @@ public final class H2 extends SyncLite {
     }
     
     
-	public static synchronized final void initialize(Path dbPath) throws SQLException {
+	public static final void initialize(Path dbPath) throws SQLException {
 		SyncLite.initialize(DeviceType.H2, dbPath);
 	}
 
-	public static synchronized final void initialize(Path dbPath, String deviceName) throws SQLException {
+	public static final void initialize(Path dbPath, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.H2, dbPath, deviceName);
 	}
 
-	public static synchronized final void initialize(Path dbPath, SyncLiteOptions options) throws SQLException {
+	public static final void initialize(Path dbPath, SyncLiteOptions options) throws SQLException {
 		SyncLite.initialize(DeviceType.H2, dbPath, options);
 	}
 
-	public static synchronized final void initialize(Path dbPath, SyncLiteOptions options, String deviceName) throws SQLException {
+	public static final void initialize(Path dbPath, SyncLiteOptions options, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.H2, dbPath, options, deviceName);
 	}
 
-	public static synchronized final void initialize(Path dbPath, Path propsPath) throws SQLException {
+	public static final void initialize(Path dbPath, Path propsPath) throws SQLException {
 		SyncLite.initialize(DeviceType.H2, dbPath, propsPath);
 	}
 
-	public static synchronized final void initialize(Path dbPath, Path propsPath, String deviceName) throws SQLException {
+	public static final void initialize(Path dbPath, Path propsPath, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.H2, dbPath, propsPath, deviceName);
 	}
     
@@ -71,23 +71,6 @@ public final class H2 extends SyncLite {
 
 	protected DBProcessor getDBProcessor() {
 		return new H2Processor();
-	}
-
-	@Override
-	protected void validateLibs(Logger tracer) throws SQLException {
-		try {
-			Class.forName("org.sqlite.JDBC");
-		} catch (ClassNotFoundException e) {
-			tracer.error("Failed to load sqlite jdbc driver : " + e.getMessage());
-			throw new SQLException("Failed to load sqlite jdbc driver");
-		}    	
-		
-		try {
-    		Class.forName("org.h2.Driver");
-		} catch (ClassNotFoundException e) {
-			tracer.error("Failed to load H2 jdbc driver : " + e.getMessage());
-			throw new SQLException("Failed to load H2 jdbc driver");
-		}    	
 	}
 
 	@Override

--- a/logger/src/main/java/io/synclite/logger/H2Appender.java
+++ b/logger/src/main/java/io/synclite/logger/H2Appender.java
@@ -40,27 +40,27 @@ public final class H2Appender extends SyncLite {
     }
     
     
-	public static synchronized final void initialize(Path dbPath) throws SQLException {
+	public static final void initialize(Path dbPath) throws SQLException {
 		SyncLite.initialize(DeviceType.H2_APPENDER, dbPath);
 	}
 
-	public static synchronized final void initialize(Path dbPath, String deviceName) throws SQLException {
+	public static final void initialize(Path dbPath, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.H2_APPENDER, dbPath, deviceName);
 	}
 
-	public static synchronized final void initialize(Path dbPath, SyncLiteOptions options) throws SQLException {
+	public static final void initialize(Path dbPath, SyncLiteOptions options) throws SQLException {
 		SyncLite.initialize(DeviceType.H2_APPENDER, dbPath, options);
 	}
 
-	public static synchronized final void initialize(Path dbPath, SyncLiteOptions options, String deviceName) throws SQLException {
+	public static final void initialize(Path dbPath, SyncLiteOptions options, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.H2_APPENDER, dbPath, options, deviceName);
 	}
 
-	public static synchronized final void initialize(Path dbPath, Path propsPath) throws SQLException {
+	public static final void initialize(Path dbPath, Path propsPath) throws SQLException {
 		SyncLite.initialize(DeviceType.H2_APPENDER, dbPath, propsPath);
 	}
 
-	public static synchronized final void initialize(Path dbPath, Path propsPath, String deviceName) throws SQLException {
+	public static final void initialize(Path dbPath, Path propsPath, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.H2_APPENDER, dbPath, propsPath, deviceName);
 	}
     
@@ -72,23 +72,6 @@ public final class H2Appender extends SyncLite {
 	protected DBProcessor getDBProcessor() {
 		return new H2Processor();
 	}	
-
-	@Override
-	protected void validateLibs(Logger tracer) throws SQLException {
-		try {
-			Class.forName("org.sqlite.JDBC");
-		} catch (ClassNotFoundException e) {
-			tracer.error("Failed to load sqlite jdbc driver : " + e.getMessage());
-			throw new SQLException("Failed to load sqlite jdbc driver");
-		}    	
-		
-		try {
-    		Class.forName("org.h2.Driver");
-		} catch (ClassNotFoundException e) {
-			tracer.error("Failed to load H2 jdbc driver : " + e.getMessage());
-			throw new SQLException("Failed to load H2 jdbc driver");
-		}    	
-	}
 
 	@Override
 	protected void setDeviceTypeInOptions(SyncLiteOptions options) throws SQLException {

--- a/logger/src/main/java/io/synclite/logger/H2AppenderConnection.java
+++ b/logger/src/main/java/io/synclite/logger/H2AppenderConnection.java
@@ -67,7 +67,6 @@ public class H2AppenderConnection extends MultiWriterDBAppenderConnection {
     @Override
     final protected void doInitConn() throws SQLException  {
     	try {
-    		Class.forName("org.h2.Driver");
     		this.h2URL = "jdbc:h2:" + this.path.toString();
     		this.h2Connection = DriverManager.getConnection(h2URL, this.props);
     		connAutoCommit(false);

--- a/logger/src/main/java/io/synclite/logger/H2Connection.java
+++ b/logger/src/main/java/io/synclite/logger/H2Connection.java
@@ -68,7 +68,6 @@ public class H2Connection extends MultiWriterDBConnection {
     @Override
     final protected void doInitConn() throws SQLException  {
     	try {
-    		Class.forName("org.h2.Driver");
     		this.h2URL = "jdbc:h2:" + this.path.toString();
     		this.h2Connection = DriverManager.getConnection(h2URL, this.props);
     		connAutoCommit(false);

--- a/logger/src/main/java/io/synclite/logger/HyperSQL.java
+++ b/logger/src/main/java/io/synclite/logger/HyperSQL.java
@@ -39,27 +39,27 @@ public final class HyperSQL extends SyncLite {
     }
     
     
-	public static synchronized final void initialize(Path dbPath) throws SQLException {
+	public static final void initialize(Path dbPath) throws SQLException {
 		SyncLite.initialize(DeviceType.HYPERSQL, dbPath);
 	}
 
-	public static synchronized final void initialize(Path dbPath, String deviceName) throws SQLException {
+	public static final void initialize(Path dbPath, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.HYPERSQL, dbPath, deviceName);
 	}
 
-	public static synchronized final void initialize(Path dbPath, SyncLiteOptions options) throws SQLException {
+	public static final void initialize(Path dbPath, SyncLiteOptions options) throws SQLException {
 		SyncLite.initialize(DeviceType.HYPERSQL, dbPath, options);
 	}
 
-	public static synchronized final void initialize(Path dbPath, SyncLiteOptions options, String deviceName) throws SQLException {
+	public static final void initialize(Path dbPath, SyncLiteOptions options, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.HYPERSQL, dbPath, options, deviceName);
 	}
 
-	public static synchronized final void initialize(Path dbPath, Path propsPath) throws SQLException {
+	public static final void initialize(Path dbPath, Path propsPath) throws SQLException {
 		SyncLite.initialize(DeviceType.HYPERSQL, dbPath, propsPath);
 	}
 
-	public static synchronized final void initialize(Path dbPath, Path propsPath, String deviceName) throws SQLException {
+	public static final void initialize(Path dbPath, Path propsPath, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.HYPERSQL, dbPath, propsPath, deviceName);
 	}
     
@@ -70,23 +70,6 @@ public final class HyperSQL extends SyncLite {
 
 	protected DBProcessor getDBProcessor() {
 		return new HyperSQLProcessor();
-	}
-
-	@Override
-	protected void validateLibs(Logger tracer) throws SQLException {
-		try {
-			Class.forName("org.sqlite.JDBC");
-		} catch (ClassNotFoundException e) {
-			tracer.error("Failed to load sqlite jdbc driver : " + e.getMessage());
-			throw new SQLException("Failed to load sqlite jdbc driver");
-		}    	
-		
-		try {
-			Class.forName("org.hsqldb.jdbc.JDBCDriver");
-		} catch (ClassNotFoundException e) {
-			tracer.error("Failed to load HyperSQL jdbc driver : " + e.getMessage());
-			throw new SQLException("Failed to load HyperSQL jdbc driver");
-		}    	
 	}
 
 	@Override

--- a/logger/src/main/java/io/synclite/logger/HyperSQLAppender.java
+++ b/logger/src/main/java/io/synclite/logger/HyperSQLAppender.java
@@ -40,27 +40,27 @@ public final class HyperSQLAppender extends SyncLite {
     }
     
     
-	public static synchronized final void initialize(Path dbPath) throws SQLException {
+	public static final void initialize(Path dbPath) throws SQLException {
 		SyncLite.initialize(DeviceType.HYPERSQL_APPENDER, dbPath);
 	}
 
-	public static synchronized final void initialize(Path dbPath, String deviceName) throws SQLException {
+	public static final void initialize(Path dbPath, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.HYPERSQL_APPENDER, dbPath, deviceName);
 	}
 
-	public static synchronized final void initialize(Path dbPath, SyncLiteOptions options) throws SQLException {
+	public static final void initialize(Path dbPath, SyncLiteOptions options) throws SQLException {
 		SyncLite.initialize(DeviceType.HYPERSQL_APPENDER, dbPath, options);
 	}
 
-	public static synchronized final void initialize(Path dbPath, SyncLiteOptions options, String deviceName) throws SQLException {
+	public static final void initialize(Path dbPath, SyncLiteOptions options, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.HYPERSQL_APPENDER, dbPath, options, deviceName);
 	}
 
-	public static synchronized final void initialize(Path dbPath, Path propsPath) throws SQLException {
+	public static final void initialize(Path dbPath, Path propsPath) throws SQLException {
 		SyncLite.initialize(DeviceType.HYPERSQL_APPENDER, dbPath, propsPath);
 	}
 
-	public static synchronized final void initialize(Path dbPath, Path propsPath, String deviceName) throws SQLException {
+	public static final void initialize(Path dbPath, Path propsPath, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.HYPERSQL_APPENDER, dbPath, propsPath, deviceName);
 	}
     
@@ -72,23 +72,6 @@ public final class HyperSQLAppender extends SyncLite {
 	protected DBProcessor getDBProcessor() {
 		return new HyperSQLProcessor();
 	}	
-
-	@Override
-	protected void validateLibs(Logger tracer) throws SQLException {
-		try {
-			Class.forName("org.sqlite.JDBC");
-		} catch (ClassNotFoundException e) {
-			tracer.error("Failed to load sqlite jdbc driver : " + e.getMessage());
-			throw new SQLException("Failed to load sqlite jdbc driver");
-		}    	
-		
-		try {
-			Class.forName("org.hsqldb.jdbc.JDBCDriver");
-		} catch (ClassNotFoundException e) {
-			tracer.error("Failed to load HyperSQL jdbc driver : " + e.getMessage());
-			throw new SQLException("Failed to load HyperSQL jdbc driver");
-		}    	
-	}
 
 	@Override
 	protected void setDeviceTypeInOptions(SyncLiteOptions options) throws SQLException {

--- a/logger/src/main/java/io/synclite/logger/HyperSQLAppenderConnection.java
+++ b/logger/src/main/java/io/synclite/logger/HyperSQLAppenderConnection.java
@@ -68,7 +68,6 @@ public class HyperSQLAppenderConnection extends MultiWriterDBAppenderConnection 
     @Override
     final protected void doInitConn() throws SQLException  {
     	try {
-            Class.forName("org.hsqldb.jdbc.JDBCDriver");
     		this.hsqlDBURL = "jdbc:hsqldb:" + this.path.toString();
     		this.hsqlDBConnection = DriverManager.getConnection(hsqlDBURL, this.props);
     		connAutoCommit(false);

--- a/logger/src/main/java/io/synclite/logger/HyperSQLConnection.java
+++ b/logger/src/main/java/io/synclite/logger/HyperSQLConnection.java
@@ -69,8 +69,7 @@ public class HyperSQLConnection extends MultiWriterDBConnection {
     @Override
     final protected void doInitConn() throws SQLException  {
     	try {
-            Class.forName("org.hsqldb.jdbc.JDBCDriver");
-    		this.hsqlDBURL = "jdbc:hsqldb:" + this.path.toString();
+    		this.hsqlDBURL = "jdbc:hsqldb:file:" + this.path.toString();
     		this.hsqlDBConnection = DriverManager.getConnection(hsqlDBURL, this.props);
     		connAutoCommit(false);
     	} catch (Exception e) {

--- a/logger/src/main/java/io/synclite/logger/HyperSQLProcessor.java
+++ b/logger/src/main/java/io/synclite/logger/HyperSQLProcessor.java
@@ -85,7 +85,7 @@ public class HyperSQLProcessor extends MultiWriterDBProcessor {
 
 		@Override
 		protected Connection getSrcConnection(Path srcDB) throws SQLException {
-			String url = "jdbc:hsqldb:" + srcDB;
+			String url = "jdbc:hsqldb:file:" + srcDB;
 			Connection conn = DriverManager.getConnection(url);
 			conn.setAutoCommit(false);
 			conn.setTransactionIsolation(Connection.TRANSACTION_SERIALIZABLE);

--- a/logger/src/main/java/io/synclite/logger/Main.java
+++ b/logger/src/main/java/io/synclite/logger/Main.java
@@ -92,8 +92,8 @@ public class Main {
 
 			//testDemoDBTran();
 			//testSQLite();
-			//testSQLiteAppender();
-			testDuckDB();
+			testSQLiteAppender();
+			//testDuckDB();
 			//testDuckDBAppender();
 			//testH2();
 			//testH2Appender();
@@ -811,7 +811,7 @@ public class Main {
 		Path config = syncLiteLoggerConfig;	
 		SQLite.initialize(dbPath, config, "testSQLiteBasic");
 
-		SQLite.initialize(dbPath);
+		//SQLite.initialize(dbPath);
 		String url = "jdbc:synclite_sqlite:" + dbPath;
 
 		{
@@ -881,23 +881,24 @@ public class Main {
 		{
 
 			try (Connection conn = DriverManager.getConnection(url)) {
-				//conn.setAutoCommit(false);
+				conn.setAutoCommit(false);
 				try (Statement stmt = conn.createStatement()) {
 					stmt.execute("create table if not exists t1(a int, b int)");
-					((SyncLiteAppenderStatement) stmt).executeUnlogged("insert into t1 values(0,0)");
+					//((SyncLiteAppenderStatement) stmt).executeUnlogged("insert into t1 values(0,0)");
+					
 				}
 
 				try (PreparedStatement pstmt = conn.prepareStatement("INSERT INTO t1 VALUES(?,?)")) {
 
-					for (int i = 1; i <= 1000010; ++i) {
+					for (int i = 1; i <= 100; ++i) {
 						pstmt.setInt(1, i);
 						pstmt.setInt(2, i);
 						pstmt.addBatch();						
 					}
 					pstmt.executeBatch();
 				}			
-
-				//conn.commit();
+				conn.commit();
+				
 			}
 		}
 	}
@@ -959,6 +960,10 @@ public class Main {
 					stmt.executeUpdate("insert into t1 values(0,0)");
 				}
 
+				try (PreparedStatement pstmt = conn.prepareStatement("select a, b from t1")) {
+					pstmt.executeQuery();
+				}
+				
 				try (PreparedStatement pstmt = conn.prepareStatement("INSERT INTO t1(a, b) VALUES(?,?)")) {
 					for (int i = 1; i <= 100; ++i) {
 						pstmt.setInt(1, i);
@@ -1036,6 +1041,10 @@ public class Main {
 					stmt.executeUpdate("insert into t1 values(0,0)");
 				}
 
+				try (PreparedStatement pstmt = conn.prepareStatement("select a,b from t1")) {
+					pstmt.executeQuery();
+				}
+				
 				try (PreparedStatement pstmt = conn.prepareStatement("INSERT INTO t1(a, b) VALUES(?,?)")) {
 					for (int i = 1; i <= 100; ++i) {
 						pstmt.setInt(1, i);

--- a/logger/src/main/java/io/synclite/logger/MultiWriterDBAppenderConnection.java
+++ b/logger/src/main/java/io/synclite/logger/MultiWriterDBAppenderConnection.java
@@ -31,7 +31,7 @@ public abstract class MultiWriterDBAppenderConnection extends SyncLiteAppenderCo
 	protected static final String insertCommitLoggerSql = "INSERT INTO synclite_txn(commit_id, operation_id) VALUES(?, ?)";
 
 	public MultiWriterDBAppenderConnection(String url, String fileName, Properties props) throws SQLException {
-		super("jdbc:sqlite:" + Path.of(fileName + ".synclite", Path.of(fileName).getFileName().toString() + ".sqlite").toString(), Path.of(fileName + ".synclite", Path.of(fileName).getFileName().toString() + ".sqlite").toString(), props);
+		super("jdbc:sqlite:" + SyncLite.getSQLiteSchemaFilePath(Path.of(fileName)).toString(), SyncLite.getSQLiteSchemaFilePath(Path.of(fileName)).toString() , props);
 		this.cmdStager = new EventSQLStager(Path.of(fileName), this.sqlLogger.options, commitId);
 		this.dbProcessor = nativeDBProcessor();
 	}

--- a/logger/src/main/java/io/synclite/logger/MultiWriterDBConnection.java
+++ b/logger/src/main/java/io/synclite/logger/MultiWriterDBConnection.java
@@ -31,7 +31,7 @@ public abstract class MultiWriterDBConnection extends SyncLiteConnection {
 	protected static final String insertCommitLoggerSql = "INSERT INTO synclite_txn(commit_id, operation_id) VALUES(?, ?)";
 
 	public MultiWriterDBConnection(String url, String fileName, Properties props) throws SQLException {
-		super("jdbc:sqlite:" + Path.of(fileName + ".synclite", Path.of(fileName).getFileName().toString() + ".sqlite").toString(), Path.of(fileName + ".synclite", Path.of(fileName).getFileName().toString() + ".sqlite").toString(), props);
+		super("jdbc:sqlite:" + SyncLite.getSQLiteSchemaFilePath(Path.of(fileName)).toString(), SyncLite.getSQLiteSchemaFilePath(Path.of(fileName)).toString() , props);
 		this.cmdStager = new TxnSQLStager(Path.of(fileName), this.sqlLogger.options, commitId);
 		this.dbProcessor = nativeDBProcessor();
 	}	

--- a/logger/src/main/java/io/synclite/logger/SQLLogger.java
+++ b/logger/src/main/java/io/synclite/logger/SQLLogger.java
@@ -65,11 +65,11 @@ abstract class SQLLogger extends Thread {
 	protected String deviceName;
 	protected AtomicLong logSegmentSequenceNumber = new AtomicLong(-1);
 	protected AtomicLong dataFileSequenceNumber = new AtomicLong(-1);
-	protected long logSegmentLogCount;
+	protected volatile long logSegmentLogCount;
 	protected long currentTxnCommitId;
-	protected long currentTxnLogCount;
+	protected volatile long currentTxnLogCount;
 	protected long currentBatchLogCount;
-	protected long lastLogSegmentCreateTime;
+	protected volatile long lastLogSegmentCreateTime;
 	protected long restartMasterCommitID;
 	protected long restartSlaveCommitID;
 	protected long currentOperationId;
@@ -90,7 +90,7 @@ abstract class SQLLogger extends Thread {
 	protected SyncLiteOptions options;
 	protected Logger tracer;
 	protected LogSegmentPlacer logSegmentPlacer;
-	private boolean terminateInProgress;
+	private volatile boolean terminateInProgress;
 	protected AtomicBoolean isHealthy = new AtomicBoolean(true);
 	private SyncLiteAppLock appLock = new SyncLiteAppLock();
 	private static AtomicLong latestGeneratedCommitId = new AtomicLong(System.currentTimeMillis());

--- a/logger/src/main/java/io/synclite/logger/SQLite.java
+++ b/logger/src/main/java/io/synclite/logger/SQLite.java
@@ -39,27 +39,27 @@ public final class SQLite extends SyncLite {
     }
     
     
-	public static synchronized final void initialize(Path dbPath) throws SQLException {
+	public static final void initialize(Path dbPath) throws SQLException {
 		SyncLite.initialize(DeviceType.SQLITE, dbPath);
 	}
 
-	public static synchronized final void initialize(Path dbPath, String deviceName) throws SQLException {
+	public static final void initialize(Path dbPath, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.SQLITE, dbPath, deviceName);
 	}
 
-	public static synchronized final void initialize(Path dbPath, SyncLiteOptions options) throws SQLException {
+	public static final void initialize(Path dbPath, SyncLiteOptions options) throws SQLException {
 		SyncLite.initialize(DeviceType.SQLITE, dbPath, options);
 	}
 
-	public static synchronized final void initialize(Path dbPath, SyncLiteOptions options, String deviceName) throws SQLException {
+	public static final void initialize(Path dbPath, SyncLiteOptions options, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.SQLITE, dbPath, options, deviceName);
 	}
 
-	public static synchronized final void initialize(Path dbPath, Path propsPath) throws SQLException {
+	public static final void initialize(Path dbPath, Path propsPath) throws SQLException {
 		SyncLite.initialize(DeviceType.SQLITE, dbPath, propsPath);
 	}
 
-	public static synchronized final void initialize(Path dbPath, Path propsPath, String deviceName) throws SQLException {
+	public static final void initialize(Path dbPath, Path propsPath, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.SQLITE, dbPath, propsPath, deviceName);
 	}
     
@@ -70,16 +70,6 @@ public final class SQLite extends SyncLite {
 
 	protected DBProcessor getDBProcessor() {
 		return new SQLiteProcessor();
-	}
-
-	@Override
-	protected void validateLibs(Logger tracer) throws SQLException {
-		try {
-			Class.forName("org.sqlite.JDBC");
-		} catch (ClassNotFoundException e) {
-			tracer.error("Failed to load sqlite jdbc driver : " + e.getMessage());
-			throw new SQLException("Failed to load sqlite jdbc driver");
-		}    	
 	}
 
 	@Override
@@ -95,5 +85,10 @@ public final class SQLite extends SyncLite {
     		AsyncTxnLogger.getInstance(dbPath, options, tracer);    		
     	}
 	}	
-	
+
+	@Override
+	protected boolean requiresSQLiteSchemaFile() {
+		return false;
+	}
+
 }

--- a/logger/src/main/java/io/synclite/logger/SQLiteAppender.java
+++ b/logger/src/main/java/io/synclite/logger/SQLiteAppender.java
@@ -39,27 +39,27 @@ public class SQLiteAppender extends SyncLite  {
     }
     
     
-	public static synchronized final void initialize(Path dbPath) throws SQLException {
+	public static final void initialize(Path dbPath) throws SQLException {
 		SyncLite.initialize(DeviceType.SQLITE_APPENDER, dbPath);
 	}
 
-	public static synchronized final void initialize(Path dbPath, String deviceName) throws SQLException {
+	public static final void initialize(Path dbPath, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.SQLITE_APPENDER, dbPath, deviceName);
 	}
 
-	public static synchronized final void initialize(Path dbPath, SyncLiteOptions options) throws SQLException {
+	public static final void initialize(Path dbPath, SyncLiteOptions options) throws SQLException {
 		SyncLite.initialize(DeviceType.SQLITE_APPENDER, dbPath, options);
 	}
 
-	public static synchronized final void initialize(Path dbPath, SyncLiteOptions options, String deviceName) throws SQLException {
+	public static final void initialize(Path dbPath, SyncLiteOptions options, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.SQLITE_APPENDER, dbPath, options, deviceName);
 	}
 
-	public static synchronized final void initialize(Path dbPath, Path propsPath) throws SQLException {
+	public static final void initialize(Path dbPath, Path propsPath) throws SQLException {
 		SyncLite.initialize(DeviceType.SQLITE_APPENDER, dbPath, propsPath);
 	}
 
-	public static synchronized final void initialize(Path dbPath, Path propsPath, String deviceName) throws SQLException {
+	public static final void initialize(Path dbPath, Path propsPath, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.SQLITE_APPENDER, dbPath, propsPath, deviceName);
 	}
     
@@ -73,16 +73,6 @@ public class SQLiteAppender extends SyncLite  {
 	}	
 
 	@Override
-	protected void validateLibs(Logger tracer) throws SQLException {
-		try {
-			Class.forName("org.sqlite.JDBC");
-		} catch (ClassNotFoundException e) {
-			tracer.error("Failed to load sqlite jdbc driver : " + e.getMessage());
-			throw new SQLException("Failed to load sqlite jdbc driver");
-		}	
-	}
-
-	@Override
 	protected void setDeviceTypeInOptions(SyncLiteOptions options) throws SQLException {
 		options.SetDeviceType(DeviceType.SQLITE_APPENDER);
 	}
@@ -92,4 +82,10 @@ public class SQLiteAppender extends SyncLite  {
 		//Use SyncEventLogger for this device.
 		SyncEventLogger.getInstance(dbPath, options, tracer);
 	}
+
+	@Override
+	protected boolean requiresSQLiteSchemaFile() {
+		return false;
+	}
+
 }

--- a/logger/src/main/java/io/synclite/logger/Streaming.java
+++ b/logger/src/main/java/io/synclite/logger/Streaming.java
@@ -35,27 +35,27 @@ public final class Streaming extends SyncLite {
         return new StreamingConnection(url, extractAddress(url, PREFIX), prop);
     }
         
-	public static synchronized final void initialize(Path dbPath) throws SQLException {
+	public static final void initialize(Path dbPath) throws SQLException {
 		SyncLite.initialize(DeviceType.STREAMING, dbPath);
 	}
 
-	public static synchronized final void initialize(Path dbPath, String deviceName) throws SQLException {
+	public static final void initialize(Path dbPath, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.STREAMING, dbPath, deviceName);
 	}
 
-	public static synchronized final void initialize(Path dbPath, SyncLiteOptions options) throws SQLException {
+	public static final void initialize(Path dbPath, SyncLiteOptions options) throws SQLException {
 		SyncLite.initialize(DeviceType.STREAMING, dbPath, options);
 	}
 
-	public static synchronized final void initialize(Path dbPath, SyncLiteOptions options, String deviceName) throws SQLException {
+	public static final void initialize(Path dbPath, SyncLiteOptions options, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.STREAMING, dbPath, options, deviceName);
 	}
 
-	public static synchronized final void initialize(Path dbPath, Path propsPath) throws SQLException {
+	public static final void initialize(Path dbPath, Path propsPath) throws SQLException {
 		SyncLite.initialize(DeviceType.STREAMING, dbPath, propsPath);
 	}
 
-	public static synchronized final void initialize(Path dbPath, Path propsPath, String deviceName) throws SQLException {
+	public static final void initialize(Path dbPath, Path propsPath, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.STREAMING, dbPath, propsPath, deviceName);
 	}
     
@@ -66,16 +66,6 @@ public final class Streaming extends SyncLite {
 
 	protected DBProcessor getDBProcessor() {
 		return new StreamingProcessor();
-	}
-
-	@Override
-	protected void validateLibs(Logger tracer) throws SQLException {
-		try {
-			Class.forName("org.sqlite.JDBC");
-		} catch (ClassNotFoundException e) {
-			tracer.error("Failed to load sqlite jdbc driver : " + e.getMessage());
-			throw new SQLException("Failed to load sqlite jdbc driver");
-		}    	
 	}
 
 	@Override
@@ -90,7 +80,7 @@ public final class Streaming extends SyncLite {
 	}	
 
 	@Override
-	protected boolean requiresMetadataFile() {
+	protected boolean requiresSQLiteSchemaFile() {
 		return false;
 	}
 

--- a/logger/src/main/java/io/synclite/logger/StreamingPreparedStatement.java
+++ b/logger/src/main/java/io/synclite/logger/StreamingPreparedStatement.java
@@ -21,9 +21,21 @@ import java.sql.SQLException;
 import org.sqlite.SQLiteConnection;
 
 public class StreamingPreparedStatement extends TelemetryPreparedStatement {
-
 	public StreamingPreparedStatement(SQLiteConnection conn, String sql) throws SQLException {
 		super(conn, sql);
+    	String strippedSql = sql.strip();
+    	String tokens[] = strippedSql.split("\\s+");
+    	if (tokens[0].equalsIgnoreCase("INSERT") && tokens[1].equalsIgnoreCase("INTO")) {
+    		SyncLiteUtils.validateInsertForTelemetryAndAppender(strippedSql);
+    	} else if ((tokens[0].equalsIgnoreCase("CREATE") || tokens[0].equalsIgnoreCase("DROP") || tokens[0].equalsIgnoreCase("ALTER")) &&
+    			(tokens[1].equalsIgnoreCase("TABLE"))
+    			) {
+    		//Allowed sql 
+    	} else if (tokens[0].equalsIgnoreCase("SELECT")) {
+    		//Allowed sql
+		} else {
+			throw new SQLException("Unsupported SQL: SyncLite streaming device does not allow SQL : " + sql + ". Allowed SQLs are CREATE TABLE, DROP TABLE, ALTER TABLE, INSERT INTO, SELECT");			
+    	}
 	}
 
 	@Override

--- a/logger/src/main/java/io/synclite/logger/StreamingStatement.java
+++ b/logger/src/main/java/io/synclite/logger/StreamingStatement.java
@@ -40,4 +40,5 @@ public class StreamingStatement extends TelemetryStatement {
 		long commitId = getConn().getCommitId();
 		getCommandStager().log(commitId, sql, args);
 	}
+	
 }

--- a/logger/src/main/java/io/synclite/logger/SyncLiteAppenderConnection.java
+++ b/logger/src/main/java/io/synclite/logger/SyncLiteAppenderConnection.java
@@ -48,7 +48,6 @@ public class SyncLiteAppenderConnection extends JDBC4Connection {
         	//Check if props are specified and props have a property "config" with value as a path to a synclite logger configuration file.
         	if (prop != null) {
         		initDevice(prop);
-        		cleanUpProps();
         		this.sqlLogger = (EventLogger) SQLLogger.findInstance(path);
         	} else {
         		//Try initializing without configs.
@@ -62,6 +61,9 @@ public class SyncLiteAppenderConnection extends JDBC4Connection {
         	if (!this.sqlLogger.isLoggerHealthy()) {
         		throw new SQLException("SyncLite logger is not healthy for device : " + path + ". Please check device trace file for more details. Please close and initialize the device again.");
         	}
+        }
+        if (this.props != null) {
+        	cleanUpProps();
         }
         initConn();
         this.commitId = this.sqlLogger.getNextCommitID();
@@ -230,7 +232,6 @@ public class SyncLiteAppenderConnection extends JDBC4Connection {
     @Override 
     public void commit() throws SQLException {
         recordCommit();
-        //2 PC
         //Flush the log in log database
         //Commit on the master database
         //

--- a/logger/src/main/java/io/synclite/logger/SyncLiteAppenderPreparedStatement.java
+++ b/logger/src/main/java/io/synclite/logger/SyncLiteAppenderPreparedStatement.java
@@ -33,11 +33,18 @@ public class SyncLiteAppenderPreparedStatement extends JDBC4PreparedStatement {
 		super(conn, sql);
     	String strippedSql = sql.strip();
     	String tokens[] = strippedSql.split("\\s+");
-		if (tokens[0].equalsIgnoreCase("INSERT") && tokens[1].equalsIgnoreCase("INTO")) {
+    	if (tokens[0].equalsIgnoreCase("INSERT") && tokens[1].equalsIgnoreCase("INTO")) {
     		SyncLiteUtils.validateInsertForTelemetryAndAppender(strippedSql);
-    	} else {
-			throw new SQLException("Unsupported SQL : SyncLite appender device does not support SQL : " + sql + ". Supported SQLs are CREATE TABLE, DROP TABLE, ALTER TABLE, INSERT INTO, SELECT");
+    	} else if ((tokens[0].equalsIgnoreCase("CREATE") || tokens[0].equalsIgnoreCase("DROP") || tokens[0].equalsIgnoreCase("ALTER")) &&
+    			(tokens[1].equalsIgnoreCase("TABLE"))
+    			) {
+    		//Allowed sql 
+    	} else if (tokens[0].equalsIgnoreCase("SELECT")) {
+    		//Allowed sql
+		} else {
+			throw new SQLException("Unsupported SQL: SyncLite appender device does not allow SQL : " + sql + ". Allowed SQLs are CREATE TABLE, DROP TABLE, ALTER TABLE, INSERT INTO, SELECT");			
     	}
+
 		this.sqlLogger = EventLogger.findInstance(getConn().getPath());
 		this.tableNameInDDL = SyncLiteUtils.getTableNameFromDDL(sql);
 	}

--- a/logger/src/main/java/io/synclite/logger/SyncLiteAppenderStatement.java
+++ b/logger/src/main/java/io/synclite/logger/SyncLiteAppenderStatement.java
@@ -57,7 +57,7 @@ public class SyncLiteAppenderStatement extends JDBC4Statement {
         return result;
     }
 
-    private final boolean executeSingleSQL(String sql) throws SQLException {
+    protected boolean executeSingleSQL(String sql) throws SQLException {
     	boolean result = false;
     	String strippedSql = sql.strip();
     	String tokens[] = strippedSql.split("\\s+");
@@ -71,12 +71,12 @@ public class SyncLiteAppenderStatement extends JDBC4Statement {
     	} else if ((tokens.length == 4) && tokens[0].equalsIgnoreCase("PUBLISH") && tokens[1].equalsIgnoreCase("COLUMN") && tokens[2].equalsIgnoreCase("LIST")) {	
 			result = executePublishColumnList(sql, tokens);
     	}  else if (tokens[0].equalsIgnoreCase("DELETE") || tokens[0].equalsIgnoreCase("UPDATE")) {
-			throw new SQLException("Unsupported SQL : SyncLite appender device does not support SQL : " + sql + ". Supported SQLs are CREATE TABLE, DROP TABLE, ALTER TABLE, INSERT INTO, SELECT");
+			throw new SQLException("Unsupported SQL: SyncLite appender device does not allow SQL : " + sql + ". Allowed SQLs are CREATE TABLE, DROP TABLE, ALTER TABLE, INSERT INTO, SELECT");
 		}  else {
 			try {
 				SyncLiteUtils.checkAndExecuteInternalAppenderSql(sql);
 			} catch (SQLException e) {
-				throw new SQLException("Unsupported SQL : SyncLite appender device does not support SQL : " + sql + ". Supported SQLs are CREATE TABLE, DROP TABLE, ALTER TABLE, INSERT INTO, SELECT");
+				throw new SQLException("Unsupported SQL: SyncLite appender device does not allow SQL : " + sql + ". Allowed SQLs are CREATE TABLE, DROP TABLE, ALTER TABLE, INSERT INTO, SELECT");
 			}
     	}
     	return result;

--- a/logger/src/main/java/io/synclite/logger/SyncLiteConnection.java
+++ b/logger/src/main/java/io/synclite/logger/SyncLiteConnection.java
@@ -47,7 +47,6 @@ public class SyncLiteConnection extends JDBC4Connection {
         	//Check if props are specified and props have a property "config" with value as a path to a synclite logger configuration file.
         	if (prop != null) {
         		initDevice(prop);
-        		cleanUpProps();
         		this.sqlLogger = (TxnLogger) SQLLogger.findInstance(path);
         	} else {
         		//Try initializing without configs.
@@ -62,6 +61,9 @@ public class SyncLiteConnection extends JDBC4Connection {
         	if (!this.sqlLogger.isLoggerHealthy()) {
         		throw new SQLException("SyncLite logger is not healthy for device : " + path + ". Please check device trace file for more details. Please close and initialize the device again.");
         	}
+        }
+        if (this.props != null) {
+        	cleanUpProps();
         }
         initConn();
         this.commitId = this.sqlLogger.getNextCommitID();
@@ -197,7 +199,6 @@ public class SyncLiteConnection extends JDBC4Connection {
     public void commit() throws SQLException {
         recordCommit();
 
-        //2 PC
         //Flush all logs in log database
         //Commit on the user database
         //Log and flush commit on log database
@@ -210,7 +211,6 @@ public class SyncLiteConnection extends JDBC4Connection {
 
     @Override
     public void rollback() throws SQLException {
-        //2 PC
         //Flush all logs in log database
         //Rollback on the user database
         //Log and flush rollback on log database

--- a/logger/src/main/java/io/synclite/logger/Telemetry.java
+++ b/logger/src/main/java/io/synclite/logger/Telemetry.java
@@ -69,16 +69,6 @@ public final class Telemetry extends SyncLite {
 	}
 
 	@Override
-	protected void validateLibs(Logger tracer) throws SQLException {
-		try {
-			Class.forName("org.sqlite.JDBC");
-		} catch (ClassNotFoundException e) {
-			tracer.error("Failed to load sqlite jdbc driver : " + e.getMessage());
-			throw new SQLException("Failed to load sqlite jdbc driver");
-		}    	
-	}
-
-	@Override
 	protected void setDeviceTypeInOptions(SyncLiteOptions options) throws SQLException {
 		options.SetDeviceType(DeviceType.TELEMETRY);
 	}
@@ -90,7 +80,7 @@ public final class Telemetry extends SyncLite {
 	}	
 
 	@Override
-	protected boolean requiresMetadataFile() {
+	protected boolean requiresSQLiteSchemaFile() {
 		return false;
 	}
 

--- a/logger/src/main/java/io/synclite/logger/TelemetryPreparedStatement.java
+++ b/logger/src/main/java/io/synclite/logger/TelemetryPreparedStatement.java
@@ -29,7 +29,7 @@ public class TelemetryPreparedStatement extends JDBC4PreparedStatement {
 		super(conn, sql);
 		List<String> subSqls = SyncLiteUtils.splitSqls(sql);
 		if (subSqls.size() > 1) {
-			throw new SQLException("SyncLite Telemetry supports a single SQL statement as part of a PreparedStatement, multiple specified  : " + sql);			
+			throw new SQLException("Unsupported SQL: SyncLite Telemetry supports a single SQL statement as part of a PreparedStatement, multiple specified  : " + sql);			
 		}
 		String stippedSql = subSqls.get(0).strip();
 		String[] tokens = stippedSql.split("\\s+");		
@@ -43,8 +43,10 @@ public class TelemetryPreparedStatement extends JDBC4PreparedStatement {
 				(tokens[1].equalsIgnoreCase("TABLE"))
 				) {
 			this.isDDL = true;
+		} else if (tokens[0].equalsIgnoreCase("SELECT")) {
+			//Allowed SQL
 		} else {
-			throw new SQLException("SyncLite Telemetry : Unsupported SQL : " + sql);
+			throw new SQLException("Unsupported SQL: " + sql);
 		}
 		this.sqlLogger = EventLogger.findInstance(getConn().getPath());
 	}
@@ -115,7 +117,11 @@ public class TelemetryPreparedStatement extends JDBC4PreparedStatement {
 
     @Override
     public ResultSet executeQuery() throws SQLException {
-    	throw new SQLException("executeQuery not allowed in Telemetry and Streaming devices");
+		String tokens[] = sql.trim().split("\\s+");
+		if (tokens[0].equalsIgnoreCase("SELECT")) {
+			return super.executeQuery(sql);
+		}
+		throw new SQLException("executeQuery allows only SELECT statements");
     }
 
 	@Override

--- a/logger/src/main/java/io/synclite/logger/TelemetryStatement.java
+++ b/logger/src/main/java/io/synclite/logger/TelemetryStatement.java
@@ -312,26 +312,11 @@ public class TelemetryStatement extends JDBC4Statement {
 
 	@Override
 	public final ResultSet executeQuery(String sql) throws SQLException {
-		/*ResultSet rs = null;
-		List<String> sqls = SyncLiteUtils.splitSqls(sql);
-		for (int i=0; i<sqls.size(); ++i) {
-			try {
-				executeSingleSQL(sqls.get(i));
-			} catch(SQLException e) {
-				if (e.getMessage().startsWith("Unsupported SQL")) {
-					String tokens[] = sql.trim().split("\\s+");
-					if (tokens[0].equalsIgnoreCase("SELECT")) {
-						rs = super.executeQuery(sql);
-					} else {
-						throw e;
-					}
-
-				}
-			}
+		String tokens[] = sql.trim().split("\\s+");
+		if (tokens[0].equalsIgnoreCase("SELECT")) {
+			return super.executeQuery(sql);
 		}
-		return rs;*/
-		
-    	throw new SQLException("executeQuery not allowed in Telemetry and Streaming devices");
+		throw new SQLException("executeQuery allows SELECT statements only");
 	}
 
 	@Override


### PR DESCRIPTION
-Single point driver loading as part of SyncLite class to avoid hangs due to concurrent driver loads 
-Fixes for executeQuery API for PreparedStatement for all kinds of devices. 
-Fixed an issue with sqlite schema file and SyncLite metadata file mixup 
-Explicitly specifying jdbc:hsqldb:file for connecting to HyperSQL DB file. 
-Fixed segment creation service lock to use synchronized block instead of reentrant lock to work when methods are for same connection called by different threads (this is possible for transactions implemented in SyncLiteDB) 
-Remove SyncLite specific props from props object ahead of passing it to individual embedded DB connections.