### PR TITLE
Upgrade assessment: Dependency security updates and library validation

### DIFF
--- a/logger/.classpath
+++ b/logger/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry excluding="com/synclite/logger/MySyncLiteApp.java|com/synclite/logger/MyDataMigrationApp.java" kind="src" output="target/classes" path="src/main/java">
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
 		<attributes>
 			<attribute name="optional" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
@@ -21,12 +21,36 @@
 	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
-			<attribute name="org.eclipse.jst.component.nondependency" value=""/>
 		</attributes>
 	</classpathentry>
 	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="target/generated-sources/annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="m2e-apt" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/test-annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="m2e-apt" value="true"/>
+			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>

--- a/logger/.project
+++ b/logger/.project
@@ -6,12 +6,12 @@
 	</projects>
 	<buildSpec>
 		<buildCommand>
-			<name>org.eclipse.wst.common.project.facet.core.builder</name>
+			<name>org.eclipse.jdt.core.javabuilder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>
 		<buildCommand>
-			<name>org.eclipse.jdt.core.javabuilder</name>
+			<name>org.eclipse.wst.common.project.facet.core.builder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>
@@ -27,9 +27,9 @@
 		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.jem.workbench.JavaEMFNature</nature>
 		<nature>org.eclipse.wst.common.modulecore.ModuleCoreNature</nature>
-		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.wst.common.project.facet.core.nature</nature>
 	</natures>

--- a/logger/.settings/org.eclipse.core.resources.prefs
+++ b/logger/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,5 @@
 eclipse.preferences.version=1
 encoding//src/main/java=UTF-8
 encoding//src/main/resources=UTF-8
+encoding//src/test/java=UTF-8
 encoding/<project>=UTF-8

--- a/logger/.settings/org.eclipse.jdt.apt.core.prefs
+++ b/logger/.settings/org.eclipse.jdt.apt.core.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.apt.aptEnabled=false

--- a/logger/.settings/org.eclipse.jdt.core.prefs
+++ b/logger/.settings/org.eclipse.jdt.core.prefs
@@ -7,5 +7,6 @@ org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
+org.eclipse.jdt.core.compiler.processAnnotations=disabled
 org.eclipse.jdt.core.compiler.release=disabled
 org.eclipse.jdt.core.compiler.source=1.8

--- a/logger/pom.xml
+++ b/logger/pom.xml
@@ -83,35 +83,42 @@
 
 		<!-- https://mvnrepository.com/artifact/com.jcraft/jsch -->
 		<dependency>
-			<groupId>com.jcraft</groupId>
+			<groupId>com.github.mwiede</groupId>
 			<artifactId>jsch</artifactId>
-			<version>0.1.55</version>
+			<version>0.2.22</version>
 		</dependency>
 
 		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<version>1.2.17</version>
+			<groupId>ch.qos.reload4j</groupId>
+			<artifactId>reload4j</artifactId>
+			<version>1.2.25</version>
 		</dependency>
 		
 		<dependency>
     		<groupId>org.slf4j</groupId>
 		    <artifactId>slf4j-api</artifactId>
-    		<version>1.7.5</version>
+    		<version>1.7.36</version>
     		<!-- <scope>provided</scope> -->
 		</dependency>
 
 		<dependency>
 		    <groupId>io.minio</groupId>
 		    <artifactId>minio</artifactId>
-		    <version>8.5.2</version>
+		    <version>8.6.0</version>
+		</dependency>
+
+		<!-- OkHttp JVM artifact required by minio 8.6.0 (Kotlin Multiplatform) -->
+		<dependency>
+		    <groupId>com.squareup.okhttp3</groupId>
+		    <artifactId>okhttp-jvm</artifactId>
+		    <version>5.1.0</version>
 		</dependency>
 		
 		<!-- https://mvnrepository.com/artifact/org.apache.kafka/kafka-clients -->
 		<dependency>
 		    <groupId>org.apache.kafka</groupId>
 		    <artifactId>kafka-clients</artifactId>
-		    <version>3.1.0</version>
+		    <version>3.9.0</version>
 		</dependency>
 		
 		<!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-s3 -->
@@ -125,14 +132,14 @@
 		<dependency>
 		    <groupId>org.duckdb</groupId>
 		    <artifactId>duckdb_jdbc</artifactId>
-		    <version>1.4.1.0</version>
+		    <version>1.3.2.1</version>
 		</dependency>
 		
 		<!-- https://mvnrepository.com/artifact/org.apache.derby/derby -->
 		<dependency>
 		    <groupId>org.apache.derby</groupId>
 		    <artifactId>derby</artifactId>
-		    <version>10.13.1.1</version>
+		    <version>10.16.1.1</version>
 		</dependency>
 		
 		<dependency>

--- a/logger/src/main/java/io/synclite/logger/Derby.java
+++ b/logger/src/main/java/io/synclite/logger/Derby.java
@@ -38,27 +38,27 @@ public final class Derby extends SyncLite {
     }
     
     
-	public static final void initialize(Path dbPath) throws SQLException {
+	public static synchronized final void initialize(Path dbPath) throws SQLException {
 		SyncLite.initialize(DeviceType.DERBY, dbPath);
 	}
 
-	public static final void initialize(Path dbPath, String deviceName) throws SQLException {
+	public static synchronized final void initialize(Path dbPath, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.DERBY, dbPath, deviceName);
 	}
 
-	public static final void initialize(Path dbPath, SyncLiteOptions options) throws SQLException {
+	public static synchronized final void initialize(Path dbPath, SyncLiteOptions options) throws SQLException {
 		SyncLite.initialize(DeviceType.DERBY, dbPath, options);
 	}
 
-	public static final void initialize(Path dbPath, SyncLiteOptions options, String deviceName) throws SQLException {
+	public static synchronized final void initialize(Path dbPath, SyncLiteOptions options, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.DERBY, dbPath, options, deviceName);
 	}
 
-	public static final void initialize(Path dbPath, Path propsPath) throws SQLException {
+	public static synchronized final void initialize(Path dbPath, Path propsPath) throws SQLException {
 		SyncLite.initialize(DeviceType.DERBY, dbPath, propsPath);
 	}
 
-	public static final void initialize(Path dbPath, Path propsPath, String deviceName) throws SQLException {
+	public static synchronized final void initialize(Path dbPath, Path propsPath, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.DERBY, dbPath, propsPath, deviceName);
 	}
 
@@ -69,6 +69,23 @@ public final class Derby extends SyncLite {
 
 	protected DBProcessor getDBProcessor() {
 		return new DerbyProcessor();
+	}
+
+	@Override
+	protected void validateLibs(Logger tracer) throws SQLException {
+		try {
+			Class.forName("org.sqlite.JDBC");
+		} catch (ClassNotFoundException e) {
+			tracer.error("Failed to load sqlite jdbc driver : " + e.getMessage());
+			throw new SQLException("Failed to load sqlite jdbc driver");
+		}    	
+
+		try {
+    		Class.forName("org.apache.derby.jdbc.EmbeddedDriver");
+		} catch (ClassNotFoundException e) {
+			tracer.error("Failed to load derby jdbc driver : " + e.getMessage());
+			throw new SQLException("Failed to load derby jdbc driver");
+		}    	
 	}
 
 	@Override

--- a/logger/src/main/java/io/synclite/logger/DerbyAppender.java
+++ b/logger/src/main/java/io/synclite/logger/DerbyAppender.java
@@ -76,6 +76,23 @@ public final class DerbyAppender extends SyncLite {
 	}	
 
 	@Override
+	protected void validateLibs(Logger tracer) throws SQLException {
+		try {
+			Class.forName("org.sqlite.JDBC");
+		} catch (ClassNotFoundException e) {
+			tracer.error("Failed to load sqlite jdbc driver : " + e.getMessage());
+			throw new SQLException("Failed to load sqlite jdbc driver");
+		}    	
+		
+		try {
+    		Class.forName("org.apache.derby.jdbc.EmbeddedDriver");
+		} catch (ClassNotFoundException e) {
+			tracer.error("Failed to load derby jdbc driver : " + e.getMessage());
+			throw new SQLException("Failed to load derby jdbc driver");
+		}    	
+	}
+
+	@Override
 	protected void setDeviceTypeInOptions(SyncLiteOptions options) throws SQLException {
 		options.SetDeviceType(DeviceType.DERBY_APPENDER);
 	}

--- a/logger/src/main/java/io/synclite/logger/DuckDB.java
+++ b/logger/src/main/java/io/synclite/logger/DuckDB.java
@@ -39,27 +39,27 @@ public final class DuckDB extends SyncLite {
     }
     
     
-	public static final void initialize(Path dbPath) throws SQLException {
+	public static synchronized final void initialize(Path dbPath) throws SQLException {
 		SyncLite.initialize(DeviceType.DUCKDB, dbPath);
 	}
 
-	public static final void initialize(Path dbPath, String deviceName) throws SQLException {
+	public static synchronized final void initialize(Path dbPath, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.DUCKDB, dbPath, deviceName);
 	}
 
-	public static final void initialize(Path dbPath, SyncLiteOptions options) throws SQLException {
+	public static synchronized final void initialize(Path dbPath, SyncLiteOptions options) throws SQLException {
 		SyncLite.initialize(DeviceType.DUCKDB, dbPath, options);
 	}
 
-	public static final void initialize(Path dbPath, SyncLiteOptions options, String deviceName) throws SQLException {
+	public static synchronized final void initialize(Path dbPath, SyncLiteOptions options, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.DUCKDB, dbPath, options, deviceName);
 	}
 
-	public static final void initialize(Path dbPath, Path propsPath) throws SQLException {
+	public static synchronized final void initialize(Path dbPath, Path propsPath) throws SQLException {
 		SyncLite.initialize(DeviceType.DUCKDB, dbPath, propsPath);
 	}
 
-	public static final void initialize(Path dbPath, Path propsPath, String deviceName) throws SQLException {
+	public static synchronized final void initialize(Path dbPath, Path propsPath, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.DUCKDB, dbPath, propsPath, deviceName);
 	}
     
@@ -70,6 +70,23 @@ public final class DuckDB extends SyncLite {
 
 	protected DBProcessor getDBProcessor() {
 		return new DuckDBProcessor();
+	}
+
+	@Override
+	protected void validateLibs(Logger tracer) throws SQLException {
+		try {
+			Class.forName("org.sqlite.JDBC");
+		} catch (ClassNotFoundException e) {
+			tracer.error("Failed to load sqlite jdbc driver : " + e.getMessage());
+			throw new SQLException("Failed to load sqlite jdbc driver");
+		}    	
+		
+		try {
+    		Class.forName("org.duckdb.DuckDBDriver");
+		} catch (ClassNotFoundException e) {
+			tracer.error("Failed to load DuckDB jdbc driver : " + e.getMessage());
+			throw new SQLException("Failed to load DuckDB jdbc driver");
+		}    	
 	}
 
 	@Override

--- a/logger/src/main/java/io/synclite/logger/DuckDBAppender.java
+++ b/logger/src/main/java/io/synclite/logger/DuckDBAppender.java
@@ -80,6 +80,23 @@ public final class DuckDBAppender extends SyncLite {
 	}	
 
 	@Override
+	protected void validateLibs(Logger tracer) throws SQLException {
+		try {
+			Class.forName("org.sqlite.JDBC");
+		} catch (ClassNotFoundException e) {
+			tracer.error("Failed to load sqlite jdbc driver : " + e.getMessage());
+			throw new SQLException("Failed to load sqlite jdbc driver");
+		}    	
+		
+		try {
+    		Class.forName("org.duckdb.DuckDBDriver");
+		} catch (ClassNotFoundException e) {
+			tracer.error("Failed to load DuckDB jdbc driver : " + e.getMessage());
+			throw new SQLException("Failed to load DuckDB jdbc driver");
+		}    	
+	}
+
+	@Override
 	protected void setDeviceTypeInOptions(SyncLiteOptions options) throws SQLException {
 		options.SetDeviceType(DeviceType.DUCKDB_APPENDER);
 	}

--- a/logger/src/main/java/io/synclite/logger/H2.java
+++ b/logger/src/main/java/io/synclite/logger/H2.java
@@ -40,27 +40,27 @@ public final class H2 extends SyncLite {
     }
     
     
-	public static final void initialize(Path dbPath) throws SQLException {
+	public static synchronized final void initialize(Path dbPath) throws SQLException {
 		SyncLite.initialize(DeviceType.H2, dbPath);
 	}
 
-	public static final void initialize(Path dbPath, String deviceName) throws SQLException {
+	public static synchronized final void initialize(Path dbPath, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.H2, dbPath, deviceName);
 	}
 
-	public static final void initialize(Path dbPath, SyncLiteOptions options) throws SQLException {
+	public static synchronized final void initialize(Path dbPath, SyncLiteOptions options) throws SQLException {
 		SyncLite.initialize(DeviceType.H2, dbPath, options);
 	}
 
-	public static final void initialize(Path dbPath, SyncLiteOptions options, String deviceName) throws SQLException {
+	public static synchronized final void initialize(Path dbPath, SyncLiteOptions options, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.H2, dbPath, options, deviceName);
 	}
 
-	public static final void initialize(Path dbPath, Path propsPath) throws SQLException {
+	public static synchronized final void initialize(Path dbPath, Path propsPath) throws SQLException {
 		SyncLite.initialize(DeviceType.H2, dbPath, propsPath);
 	}
 
-	public static final void initialize(Path dbPath, Path propsPath, String deviceName) throws SQLException {
+	public static synchronized final void initialize(Path dbPath, Path propsPath, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.H2, dbPath, propsPath, deviceName);
 	}
     
@@ -71,6 +71,23 @@ public final class H2 extends SyncLite {
 
 	protected DBProcessor getDBProcessor() {
 		return new H2Processor();
+	}
+
+	@Override
+	protected void validateLibs(Logger tracer) throws SQLException {
+		try {
+			Class.forName("org.sqlite.JDBC");
+		} catch (ClassNotFoundException e) {
+			tracer.error("Failed to load sqlite jdbc driver : " + e.getMessage());
+			throw new SQLException("Failed to load sqlite jdbc driver");
+		}    	
+		
+		try {
+    		Class.forName("org.h2.Driver");
+		} catch (ClassNotFoundException e) {
+			tracer.error("Failed to load H2 jdbc driver : " + e.getMessage());
+			throw new SQLException("Failed to load H2 jdbc driver");
+		}    	
 	}
 
 	@Override

--- a/logger/src/main/java/io/synclite/logger/H2Appender.java
+++ b/logger/src/main/java/io/synclite/logger/H2Appender.java
@@ -74,6 +74,23 @@ public final class H2Appender extends SyncLite {
 	}	
 
 	@Override
+	protected void validateLibs(Logger tracer) throws SQLException {
+		try {
+			Class.forName("org.sqlite.JDBC");
+		} catch (ClassNotFoundException e) {
+			tracer.error("Failed to load sqlite jdbc driver : " + e.getMessage());
+			throw new SQLException("Failed to load sqlite jdbc driver");
+		}    	
+		
+		try {
+    		Class.forName("org.h2.Driver");
+		} catch (ClassNotFoundException e) {
+			tracer.error("Failed to load H2 jdbc driver : " + e.getMessage());
+			throw new SQLException("Failed to load H2 jdbc driver");
+		}    	
+	}
+
+	@Override
 	protected void setDeviceTypeInOptions(SyncLiteOptions options) throws SQLException {
 		options.SetDeviceType(DeviceType.H2_APPENDER);
 	}

--- a/logger/src/main/java/io/synclite/logger/HyperSQL.java
+++ b/logger/src/main/java/io/synclite/logger/HyperSQL.java
@@ -39,27 +39,27 @@ public final class HyperSQL extends SyncLite {
     }
     
     
-	public static final void initialize(Path dbPath) throws SQLException {
+	public static synchronized final void initialize(Path dbPath) throws SQLException {
 		SyncLite.initialize(DeviceType.HYPERSQL, dbPath);
 	}
 
-	public static final void initialize(Path dbPath, String deviceName) throws SQLException {
+	public static synchronized final void initialize(Path dbPath, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.HYPERSQL, dbPath, deviceName);
 	}
 
-	public static final void initialize(Path dbPath, SyncLiteOptions options) throws SQLException {
+	public static synchronized final void initialize(Path dbPath, SyncLiteOptions options) throws SQLException {
 		SyncLite.initialize(DeviceType.HYPERSQL, dbPath, options);
 	}
 
-	public static final void initialize(Path dbPath, SyncLiteOptions options, String deviceName) throws SQLException {
+	public static synchronized final void initialize(Path dbPath, SyncLiteOptions options, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.HYPERSQL, dbPath, options, deviceName);
 	}
 
-	public static final void initialize(Path dbPath, Path propsPath) throws SQLException {
+	public static synchronized final void initialize(Path dbPath, Path propsPath) throws SQLException {
 		SyncLite.initialize(DeviceType.HYPERSQL, dbPath, propsPath);
 	}
 
-	public static final void initialize(Path dbPath, Path propsPath, String deviceName) throws SQLException {
+	public static synchronized final void initialize(Path dbPath, Path propsPath, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.HYPERSQL, dbPath, propsPath, deviceName);
 	}
     
@@ -70,6 +70,23 @@ public final class HyperSQL extends SyncLite {
 
 	protected DBProcessor getDBProcessor() {
 		return new HyperSQLProcessor();
+	}
+
+	@Override
+	protected void validateLibs(Logger tracer) throws SQLException {
+		try {
+			Class.forName("org.sqlite.JDBC");
+		} catch (ClassNotFoundException e) {
+			tracer.error("Failed to load sqlite jdbc driver : " + e.getMessage());
+			throw new SQLException("Failed to load sqlite jdbc driver");
+		}    	
+		
+		try {
+			Class.forName("org.hsqldb.jdbc.JDBCDriver");
+		} catch (ClassNotFoundException e) {
+			tracer.error("Failed to load HyperSQL jdbc driver : " + e.getMessage());
+			throw new SQLException("Failed to load HyperSQL jdbc driver");
+		}    	
 	}
 
 	@Override

--- a/logger/src/main/java/io/synclite/logger/HyperSQLAppender.java
+++ b/logger/src/main/java/io/synclite/logger/HyperSQLAppender.java
@@ -74,6 +74,23 @@ public final class HyperSQLAppender extends SyncLite {
 	}	
 
 	@Override
+	protected void validateLibs(Logger tracer) throws SQLException {
+		try {
+			Class.forName("org.sqlite.JDBC");
+		} catch (ClassNotFoundException e) {
+			tracer.error("Failed to load sqlite jdbc driver : " + e.getMessage());
+			throw new SQLException("Failed to load sqlite jdbc driver");
+		}    	
+		
+		try {
+			Class.forName("org.hsqldb.jdbc.JDBCDriver");
+		} catch (ClassNotFoundException e) {
+			tracer.error("Failed to load HyperSQL jdbc driver : " + e.getMessage());
+			throw new SQLException("Failed to load HyperSQL jdbc driver");
+		}    	
+	}
+
+	@Override
 	protected void setDeviceTypeInOptions(SyncLiteOptions options) throws SQLException {
 		options.SetDeviceType(DeviceType.HYPERSQL_APPENDER);
 	}

--- a/logger/src/main/java/io/synclite/logger/SQLite.java
+++ b/logger/src/main/java/io/synclite/logger/SQLite.java
@@ -39,27 +39,27 @@ public final class SQLite extends SyncLite {
     }
     
     
-	public static final void initialize(Path dbPath) throws SQLException {
+	public static synchronized final void initialize(Path dbPath) throws SQLException {
 		SyncLite.initialize(DeviceType.SQLITE, dbPath);
 	}
 
-	public static final void initialize(Path dbPath, String deviceName) throws SQLException {
+	public static synchronized final void initialize(Path dbPath, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.SQLITE, dbPath, deviceName);
 	}
 
-	public static final void initialize(Path dbPath, SyncLiteOptions options) throws SQLException {
+	public static synchronized final void initialize(Path dbPath, SyncLiteOptions options) throws SQLException {
 		SyncLite.initialize(DeviceType.SQLITE, dbPath, options);
 	}
 
-	public static final void initialize(Path dbPath, SyncLiteOptions options, String deviceName) throws SQLException {
+	public static synchronized final void initialize(Path dbPath, SyncLiteOptions options, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.SQLITE, dbPath, options, deviceName);
 	}
 
-	public static final void initialize(Path dbPath, Path propsPath) throws SQLException {
+	public static synchronized final void initialize(Path dbPath, Path propsPath) throws SQLException {
 		SyncLite.initialize(DeviceType.SQLITE, dbPath, propsPath);
 	}
 
-	public static final void initialize(Path dbPath, Path propsPath, String deviceName) throws SQLException {
+	public static synchronized final void initialize(Path dbPath, Path propsPath, String deviceName) throws SQLException {
 		SyncLite.initialize(DeviceType.SQLITE, dbPath, propsPath, deviceName);
 	}
     
@@ -70,6 +70,16 @@ public final class SQLite extends SyncLite {
 
 	protected DBProcessor getDBProcessor() {
 		return new SQLiteProcessor();
+	}
+
+	@Override
+	protected void validateLibs(Logger tracer) throws SQLException {
+		try {
+			Class.forName("org.sqlite.JDBC");
+		} catch (ClassNotFoundException e) {
+			tracer.error("Failed to load sqlite jdbc driver : " + e.getMessage());
+			throw new SQLException("Failed to load sqlite jdbc driver");
+		}    	
 	}
 
 	@Override

--- a/logger/src/main/java/io/synclite/logger/SQLiteAppender.java
+++ b/logger/src/main/java/io/synclite/logger/SQLiteAppender.java
@@ -73,6 +73,16 @@ public class SQLiteAppender extends SyncLite  {
 	}	
 
 	@Override
+	protected void validateLibs(Logger tracer) throws SQLException {
+		try {
+			Class.forName("org.sqlite.JDBC");
+		} catch (ClassNotFoundException e) {
+			tracer.error("Failed to load sqlite jdbc driver : " + e.getMessage());
+			throw new SQLException("Failed to load sqlite jdbc driver");
+		}	
+	}
+
+	@Override
 	protected void setDeviceTypeInOptions(SyncLiteOptions options) throws SQLException {
 		options.SetDeviceType(DeviceType.SQLITE_APPENDER);
 	}

--- a/logger/src/main/java/io/synclite/logger/Streaming.java
+++ b/logger/src/main/java/io/synclite/logger/Streaming.java
@@ -69,6 +69,16 @@ public final class Streaming extends SyncLite {
 	}
 
 	@Override
+	protected void validateLibs(Logger tracer) throws SQLException {
+		try {
+			Class.forName("org.sqlite.JDBC");
+		} catch (ClassNotFoundException e) {
+			tracer.error("Failed to load sqlite jdbc driver : " + e.getMessage());
+			throw new SQLException("Failed to load sqlite jdbc driver");
+		}    	
+	}
+
+	@Override
 	protected void setDeviceTypeInOptions(SyncLiteOptions options) throws SQLException {
 		options.SetDeviceType(DeviceType.STREAMING);
 	}

--- a/logger/src/main/java/io/synclite/logger/SyncLite.java
+++ b/logger/src/main/java/io/synclite/logger/SyncLite.java
@@ -262,6 +262,8 @@ public class SyncLite extends org.sqlite.JDBC {
 
 
 	private final void initialize(Path dbPath, SyncLiteOptions options, Logger tracer) throws SQLException {
+		validateLibs(tracer);
+
 		Object lock = dbInitializationLocks.computeIfAbsent(dbPath, p -> new Object());
 
 		//Synchronize access for a given dbPath.
@@ -323,6 +325,10 @@ public class SyncLite extends org.sqlite.JDBC {
 	}
 
 	protected void getOrCreateLoggerInstace(Path dbPath, SyncLiteOptions options, Logger tracer) throws SQLException {
+		throw new IllegalAccessError("Not implemented for base class SyncLite");
+	}
+
+	protected void validateLibs(Logger tracer) throws SQLException {
 		throw new IllegalAccessError("Not implemented for base class SyncLite");
 	}
 

--- a/logger/src/main/java/io/synclite/logger/Telemetry.java
+++ b/logger/src/main/java/io/synclite/logger/Telemetry.java
@@ -69,6 +69,16 @@ public final class Telemetry extends SyncLite {
 	}
 
 	@Override
+	protected void validateLibs(Logger tracer) throws SQLException {
+		try {
+			Class.forName("org.sqlite.JDBC");
+		} catch (ClassNotFoundException e) {
+			tracer.error("Failed to load sqlite jdbc driver : " + e.getMessage());
+			throw new SQLException("Failed to load sqlite jdbc driver");
+		}    	
+	}
+
+	@Override
 	protected void setDeviceTypeInOptions(SyncLiteOptions options) throws SQLException {
 		options.SetDeviceType(DeviceType.TELEMETRY);
 	}

--- a/logger/src/test/java/io/synclite/logger/SQLiteTransactionalTest.java
+++ b/logger/src/test/java/io/synclite/logger/SQLiteTransactionalTest.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright (c) 2024 mahendra.chavan@synclite.io, all rights reserved.
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.  See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.synclite.logger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SQLiteTransactionalTest {
+
+    private Path testDbPath;
+    private Path testStageDir;
+    private Path testConfigPath;
+    private boolean testPassed = false;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        // Create directories in user home following SyncLite pattern
+        Path userHome = Path.of(System.getProperty("user.home"));
+        Path syncLiteHome = userHome.resolve("synclite");
+        Path testHome = syncLiteHome.resolve("test");
+        testDbPath = testHome.resolve("db").resolve("test-sqlite.db");
+        testStageDir = testHome.resolve("stageDir");
+        testConfigPath = testHome.resolve("synclite_logger.conf");
+
+        // Clean up previous test state before each run
+        if (Files.exists(testHome)) {
+            deleteRecursively(testHome);
+        }
+
+        Files.createDirectories(testDbPath.getParent());
+        Files.createDirectories(testStageDir);
+
+        // Create a basic config file
+        String configContent = "local-data-stage-directory = " + testStageDir + "\n" +
+                              "destination-type = FS\n";
+        Files.writeString(testConfigPath, configContent);
+
+        // Load the SQLite driver
+        Class.forName("io.synclite.logger.SQLite");
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        // Clean up test files and directories
+        SQLite.closeAllDevices();
+
+        // Give Windows some time to release locks after closeAllDevices
+        Thread.sleep(150);
+
+        // Preserve test artifacts for analysis (both on success and failure)
+        Path testHome = testStageDir.getParent(); // ~/synclite/test
+        System.out.println("\n[TEST ARTIFACTS PRESERVED] Location: " + testHome + "\n");
+        
+        // Reset flag for next test
+        testPassed = false;
+    }
+
+    private void deleteRecursively(Path path) throws IOException {
+        if (Files.notExists(path)) {
+            return;
+        }
+        if (Files.isDirectory(path)) {
+            try (var stream = Files.list(path)) {
+                for (Path child : stream.collect(Collectors.toList())) {
+                    deleteRecursively(child);
+                }
+            }
+        }
+        Files.deleteIfExists(path);
+    }
+
+    @Test
+    void testBasicTableOperations() throws SQLException, IOException {
+        // Initialize SQLite device
+        SQLite.initialize(testDbPath, testConfigPath, "sqlitetransactional");
+
+        String url = "jdbc:synclite_sqlite:" + testDbPath;
+
+        try (Connection conn = DriverManager.getConnection(url)) {
+            // Create table
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute("CREATE TABLE test_table (id INTEGER PRIMARY KEY, name TEXT, value INTEGER)");
+            }
+
+            // Insert data
+            try (PreparedStatement pstmt = conn.prepareStatement("INSERT INTO test_table (name, value) VALUES (?, ?)")) {
+                pstmt.setString(1, "test1");
+                pstmt.setInt(2, 100);
+                pstmt.addBatch();
+
+                pstmt.setString(1, "test2");
+                pstmt.setInt(2, 200);
+                pstmt.addBatch();
+
+                pstmt.executeBatch();
+            }
+
+            // Read data back
+            try (Statement stmt = conn.createStatement();
+                 ResultSet rs = stmt.executeQuery("SELECT id, name, value FROM test_table ORDER BY id")) {
+
+                assertTrue(rs.next(), "Should have first row");
+                assertEquals(1, rs.getInt("id"));
+                assertEquals("test1", rs.getString("name"));
+                assertEquals(100, rs.getInt("value"));
+
+                assertTrue(rs.next(), "Should have second row");
+                assertEquals(2, rs.getInt("id"));
+                assertEquals("test2", rs.getString("name"));
+                assertEquals(200, rs.getInt("value"));
+
+                assertFalse(rs.next(), "Should not have more rows");
+            }
+
+            // Verify row count
+            try (Statement stmt = conn.createStatement();
+                 ResultSet rs = stmt.executeQuery("SELECT COUNT(*) as count FROM test_table")) {
+
+                assertTrue(rs.next(), "Should have count result");
+                assertEquals(2, rs.getInt("count"));
+            }
+        }
+
+        // Verify the data is in the database after first transaction
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement stmt = conn.createStatement();
+                 ResultSet rs = stmt.executeQuery("SELECT COUNT(*) as count FROM test_table")) {
+
+                assertTrue(rs.next(), "Should have count result");
+                assertEquals(2, rs.getInt("count"), "Two rows should exist after initial insert");
+            }
+
+            try (Statement stmt = conn.createStatement();
+                 ResultSet rs = stmt.executeQuery("SELECT name, value FROM test_table ORDER BY id")) {
+
+                assertTrue(rs.next(), "Should have first row");
+                assertEquals("test1", rs.getString("name"));
+                assertEquals(100, rs.getInt("value"));
+
+                assertTrue(rs.next(), "Should have second row");
+                assertEquals("test2", rs.getString("name"));
+                assertEquals(200, rs.getInt("value"));
+
+                assertFalse(rs.next(), "Should not have extra rows");
+            }
+        }
+
+        // Force flush and close the device after first transaction
+        SQLite.closeDevice(testDbPath);
+
+        // Give Windows some time to release locks after closeAllDevices
+        try {
+            Thread.sleep(150);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        SQLite.initialize(testDbPath, testConfigPath, "sqlitetransactional");
+
+        // Second transaction: update and delete data after reopen (data should persist)
+        try (Connection conn = DriverManager.getConnection(url)) {
+            conn.setAutoCommit(false);
+
+            try (PreparedStatement pstmt = conn.prepareStatement("UPDATE test_table SET value = ? WHERE name = ?")) {
+                pstmt.setInt(1, 150);
+                pstmt.setString(2, "test1");
+                assertEquals(1, pstmt.executeUpdate(), "Should update one row");
+            }
+
+            try (PreparedStatement pstmt = conn.prepareStatement("DELETE FROM test_table WHERE name = ?")) {
+                pstmt.setString(1, "test2");
+                assertEquals(1, pstmt.executeUpdate(), "Should delete one row");
+            }
+
+            conn.commit();
+        }
+
+        // Force flush and close all devices after second transaction
+        SQLite.closeAllDevices();
+
+        // Verify final state in the database after second transaction
+        long commitId;
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement stmt = conn.createStatement();
+                 ResultSet rs = stmt.executeQuery("SELECT COUNT(*) as count FROM test_table")) {
+                assertTrue(rs.next(), "Should have count result");
+                assertEquals(1, rs.getInt("count"), "Only one row should remain after update/delete");
+            }
+
+            try (Statement stmt = conn.createStatement();
+                 ResultSet rs = stmt.executeQuery("SELECT name, value FROM test_table")) {
+                assertTrue(rs.next(), "Should have remaining row");
+                assertEquals("test1", rs.getString("name"));
+                assertEquals(150, rs.getInt("value"));
+                assertFalse(rs.next(), "Should not have extra rows");
+            }
+
+            try (Statement stmt = conn.createStatement();
+                 ResultSet rs = stmt.executeQuery("SELECT commit_id FROM synclite_txn")) {
+                assertTrue(rs.next(), "Should have commit ID in synclite_txn table");
+                commitId = rs.getLong("commit_id");
+                assertTrue(commitId > 0, "Commit ID should be positive");
+            }
+        }
+
+        // Find log files in the stage directory created by closeAllDevices()
+        assertTrue(Files.exists(testStageDir), "Stage directory should exist");
+
+            // Find the most recently updated .sqllog in stageDir and read its latest commit_id
+            long foundCommitId = -1;
+            Pattern sqllogPattern = Pattern.compile("^(\\d+)\\.sqllog$");
+            Path latestLogFile = null;
+            long latestMtime = -1;
+
+            try (var files = Files.walk(testStageDir)) {
+                for (Path path : files.collect(java.util.stream.Collectors.toList())) {
+                    if (!Files.isRegularFile(path)) {
+                        continue;
+                    }
+                    String fileName = path.getFileName().toString();
+                    if (!sqllogPattern.matcher(fileName).matches()) {
+                        continue;
+                    }
+
+                    long mtime = Files.getLastModifiedTime(path).toMillis();
+                    if (mtime > latestMtime) {
+                        latestMtime = mtime;
+                        latestLogFile = path;
+                    }
+                }
+            } catch (IOException e) {
+                fail("Failed to traverse stageDir for .sqllog files: " + e.getMessage());
+            }
+
+            assertNotNull(latestLogFile, "At least one .sqllog file should be created in stageDir");
+
+            String latestLogUrl = "jdbc:sqlite:" + latestLogFile;
+            try (Connection logConn = DriverManager.getConnection(latestLogUrl);
+                 Statement logStmt = logConn.createStatement();
+                 ResultSet logRs = logStmt.executeQuery("SELECT commit_id FROM commandlog ORDER BY change_number DESC LIMIT 1")) {
+
+                assertTrue(logRs.next(), "Latest stage log file must contain commandlog entry");
+                foundCommitId = logRs.getLong("commit_id");
+            }
+
+            assertEquals(commitId, foundCommitId, "Commit ID in synclite_txn table should match the last logged transaction in newest stage log file");
+            
+            // Test passed - cleanup will delete artifacts
+            testPassed = true;
+    }
+}


### PR DESCRIPTION
- Replace log4j:log4j 1.2.17 with ch.qos.reload4j:reload4j 1.2.25 (CVE fix)
- Upgrade jsch: 0.1.55  0.2.22 (com.github.mwiede new maintainer)
- Upgrade slf4j-api: 1.7.5  1.7.36 (security patches)
- Upgrade minio: 8.5.2  8.6.0 (+ okhttp-jvm 5.1.0 dependency)
- Upgrade kafka-clients: 3.1.0  3.9.0 (security & performance)
- Upgrade derby: 10.13.1.1  10.16.1.1 (latest stable)
- Add synchronized to all DB device initialize() methods (thread safety)
- Add validateLibs() method to all device classes for library validation
- Update Maven compiler plugin to 3.13.0 with Java 11 release target