### PR TITLE
SyncLite-Backed Jedis Redis Cache Wrapper

### DIFF
--- a/logger/pom.xml
+++ b/logger/pom.xml
@@ -142,6 +142,21 @@
 		    <artifactId>kafka-clients</artifactId>
 		    <version>3.9.0</version>
 		</dependency>
+
+		<!-- https://mvnrepository.com/artifact/redis.clients/jedis -->
+		<dependency>
+		    <groupId>redis.clients</groupId>
+		    <artifactId>jedis</artifactId>
+		    <version>4.4.8</version>
+		</dependency>
+
+		<!-- In-process fake Redis server for JedisTest — no Docker or Redis install needed -->
+		<dependency>
+		    <groupId>com.github.fppt</groupId>
+		    <artifactId>jedis-mock</artifactId>
+		    <version>1.1.2</version>
+		    <scope>test</scope>
+		</dependency>
 		
 		<!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-s3 -->
 		<dependency>

--- a/logger/src/main/java/io/synclite/logger/Jedis.java
+++ b/logger/src/main/java/io/synclite/logger/Jedis.java
@@ -1,0 +1,1544 @@
+/*
+ * Copyright (c) 2024 mahendra.chavan@synclite.io, all rights reserved.
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.  See the License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package io.synclite.logger;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import redis.clients.jedis.GeoCoordinate;
+import redis.clients.jedis.StreamEntryID;
+import redis.clients.jedis.args.BitOP;
+import redis.clients.jedis.args.ListDirection;
+import redis.clients.jedis.args.ListPosition;
+import redis.clients.jedis.exceptions.JedisException;
+import redis.clients.jedis.params.GeoAddParams;
+import redis.clients.jedis.params.SetParams;
+import redis.clients.jedis.params.SortingParams;
+import redis.clients.jedis.params.ZAddParams;
+import redis.clients.jedis.params.ZParams;
+import redis.clients.jedis.params.ZRangeParams;
+import redis.clients.jedis.resps.Tuple;
+
+/**
+ * A SyncLite-backed drop-in replacement for {@link redis.clients.jedis.Jedis}.
+ *
+ * <p>Every write (set, hset, del, expire …) is first durably committed to a
+ * {@link SyncLiteStore} — which captures it to the SyncLite replication log for
+ * downstream CDC consumption — and then forwarded to Redis.  On startup the cache
+ * is automatically re-populated from the store so that Redis data survives
+ * restarts.
+ *
+ * <p><strong>Usage:</strong>
+ * <pre>
+ *   SQLiteStore.initialize(dbPath, configPath);
+ *
+ *   try (SyncLiteStore store = SQLiteStore.open(dbPath);
+ *        Jedis jedis = Jedis.builder(store).host("redis-host").port(6380).build()) {
+ *
+ *       jedis.set("user:1:name", "Alice");
+ *       jedis.hset("session:42", "token", "abc123");
+ *       String name = jedis.get("user:1:name");   // reads from Redis
+ *   }
+ * </pre>
+ *
+ * <p><strong>Store schema:</strong>
+ * <ul>
+ *   <li>{@code jedis_strings (key TEXT, value TEXT, expires_at BIGINT)} — string keys</li>
+ *   <li>{@code jedis_hashes  (hash_key TEXT, field TEXT, value TEXT, expires_at BIGINT)} — hash keys</li>
+ *   <li>{@code jedis_lists   (key TEXT, idx BIGINT, value TEXT, expires_at BIGINT)} — list keys</li>
+ *   <li>{@code jedis_sets    (key TEXT, member TEXT, expires_at BIGINT)} — set keys</li>
+ *   <li>{@code jedis_zsets   (key TEXT, score DOUBLE, member TEXT, expires_at BIGINT)} — sorted set keys</li>
+ * </ul>
+ *
+ * <p><strong>Thread safety:</strong> A single {@code Jedis} instance (like the
+ * upstream Jedis client) is <em>not</em> thread-safe.  Use one instance per thread,
+ * each backed by its own {@link SyncLiteStore} connection.
+ *
+ * <p><strong>Expired-entry purge:</strong> A background daemon thread runs
+ * {@link #purgeExpired()} at a configurable interval (default 60 s) to remove
+ * TTL-expired rows from the store.  Configure with {@link Builder#storePurgeInterval(long, TimeUnit)}.
+ * The scheduler is shut down automatically when {@link #close()} is called.
+ */
+public class Jedis extends redis.clients.jedis.Jedis {
+
+    static final String STRINGS_TABLE = "jedis_strings";
+    static final String HASHES_TABLE   = "jedis_hashes";
+    static final String LISTS_TABLE    = "jedis_lists";
+    static final String SETS_TABLE     = "jedis_sets";
+    static final String ZSETS_TABLE    = "jedis_zsets";
+
+    private static final long DEFAULT_PURGE_INTERVAL_SECONDS = 60L;
+
+    private final SyncLiteStore store;
+    private final ScheduledExecutorService purgeScheduler;
+
+    // -------------------------------------------------------------------------
+    // Builder
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns a new {@link Builder} pre-set with the given store.
+     *
+     * @param store a pre-opened {@link SyncLiteStore} — not closed by the built instance
+     */
+    public static Builder builder(SyncLiteStore store) {
+        return new Builder().store(store);
+    }
+
+    /**
+     * Returns a new {@link Builder} pre-set with the Redis host and port.
+     * Call {@link Builder#store(SyncLiteStore)} before {@link Builder#build()}.
+     */
+    public static Builder builder(String host, int port) {
+        return new Builder().host(host).port(port);
+    }
+
+    /**
+     * Fluent builder for {@link Jedis}.
+     *
+     * <pre>
+     *   // store-first
+     *   Jedis jedis = Jedis.builder(store).host("redis-host").port(6380).build();
+     *
+     *   // host/port-first
+     *   Jedis jedis = Jedis.builder("redis-host", 6380).store(store).build();
+     * </pre>
+     */
+    public static final class Builder {
+        private SyncLiteStore store;
+        private String   host          = "localhost";
+        private int      port          = 6379;
+        private long     purgeInterval = DEFAULT_PURGE_INTERVAL_SECONDS;
+        private TimeUnit purgeUnit     = TimeUnit.SECONDS;
+
+        private Builder() {}
+
+        public Builder store(SyncLiteStore store) {
+            this.store = store;
+            return this;
+        }
+
+        public Builder host(String host) {
+            this.host = host;
+            return this;
+        }
+
+        public Builder port(int port) {
+            this.port = port;
+            return this;
+        }
+
+        /** Overrides the default 60-second background purge interval. */
+        public Builder storePurgeInterval(long interval, TimeUnit unit) {
+            this.purgeInterval = interval;
+            this.purgeUnit     = unit;
+            return this;
+        }
+
+        public Jedis build() throws SQLException {
+            if (store == null) {
+                throw new IllegalStateException("SyncLiteStore must be provided via store()");
+            }
+            return new Jedis(this);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Constructor (private — use Builder)
+    // -------------------------------------------------------------------------
+
+    private Jedis(Builder b) throws SQLException {
+        super(b.host, b.port);
+        this.store = b.store;
+        this.purgeScheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "jedis-purge");
+            t.setDaemon(true);
+            return t;
+        });
+        initStoreTables();
+        warmUp();
+        purgeScheduler.scheduleAtFixedRate(() -> {
+            try {
+                purgeExpired();
+            } catch (Exception e) {
+                // do not crash the scheduler thread
+            }
+        }, b.purgeInterval, b.purgeInterval, b.purgeUnit);
+    }
+
+    // -------------------------------------------------------------------------
+    // Initialisation
+    // -------------------------------------------------------------------------
+
+    private void initStoreTables() throws SQLException {
+        String st = store.getDefaultStringType();
+
+        Map<String, String> stringsCols = new LinkedHashMap<>();
+        stringsCols.put("key",        st + " PRIMARY KEY");
+        stringsCols.put("value",      st);
+        stringsCols.put("expires_at", "BIGINT");
+        store.createTable(STRINGS_TABLE, stringsCols);
+
+        Map<String, String> hashesCols = new LinkedHashMap<>();
+        hashesCols.put("hash_key",   st);
+        hashesCols.put("field",      st);
+        hashesCols.put("value",      st);
+        hashesCols.put("expires_at", "BIGINT");
+        hashesCols.put("PRIMARY KEY", "(hash_key, field)");
+        store.createTable(HASHES_TABLE, hashesCols);
+
+        Map<String, String> listsCols = new LinkedHashMap<>();
+        listsCols.put("key",        st);
+        listsCols.put("idx",        "BIGINT");
+        listsCols.put("value",      st);
+        listsCols.put("expires_at", "BIGINT");
+        listsCols.put("PRIMARY KEY", "(key, idx)");
+        store.createTable(LISTS_TABLE, listsCols);
+
+        Map<String, String> setsCols = new LinkedHashMap<>();
+        setsCols.put("key",        st);
+        setsCols.put("member",     st);
+        setsCols.put("expires_at", "BIGINT");
+        setsCols.put("PRIMARY KEY", "(key, member)");
+        store.createTable(SETS_TABLE, setsCols);
+
+        Map<String, String> zsetsCols = new LinkedHashMap<>();
+        zsetsCols.put("key",        st);
+        zsetsCols.put("score",      "DOUBLE");
+        zsetsCols.put("member",     st);
+        zsetsCols.put("expires_at", "BIGINT");
+        zsetsCols.put("PRIMARY KEY", "(key, member)");
+        store.createTable(ZSETS_TABLE, zsetsCols);
+    }
+
+    /**
+     * Loads all non-expired entries from the backing store into Redis.
+     * Called automatically in the constructor; callers may also invoke it explicitly
+     * to re-synchronise Redis from the store (e.g. after a targeted Redis flush).
+     */
+    public void warmUp() throws SQLException {
+        long now = System.currentTimeMillis();
+
+        // --- strings ---
+        List<Map<String, Object>> stringRows = store.selectAll(STRINGS_TABLE);
+        for (Map<String, Object> row : stringRows) {
+            String key   = (String) row.get("key");
+            String value = (String) row.get("value");
+            long expiresAt = toLong(row.get("expires_at"));
+
+            if (expiresAt > 0 && expiresAt <= now) {
+                continue; // expired — skip (cleaned up lazily; see expire())
+            }
+            if (expiresAt > 0) {
+                super.psetex(key, expiresAt - now, value);
+            } else {
+                super.set(key, value);
+            }
+        }
+
+        // --- hashes ---
+        // Collect field-value pairs per hash key, honouring expiry.
+        Map<String, Map<String, String>> hashes = new LinkedHashMap<>();
+        Map<String, Long> hashExpiry = new HashMap<>();
+
+        List<Map<String, Object>> hashRows = store.selectAll(HASHES_TABLE);
+        for (Map<String, Object> row : hashRows) {
+            String hashKey = (String) row.get("hash_key");
+            String field   = (String) row.get("field");
+            String value   = (String) row.get("value");
+            long expiresAt = toLong(row.get("expires_at"));
+
+            if (expiresAt > 0 && expiresAt <= now) {
+                continue; // expired
+            }
+            hashes.computeIfAbsent(hashKey, k -> new LinkedHashMap<>()).put(field, value);
+            if (expiresAt > 0) {
+                hashExpiry.put(hashKey, expiresAt);
+            }
+        }
+
+        for (Map.Entry<String, Map<String, String>> entry : hashes.entrySet()) {
+            String hashKey = entry.getKey();
+            super.hset(hashKey, entry.getValue());
+            Long exp = hashExpiry.get(hashKey);
+            if (exp != null) {
+                super.expire(hashKey, Math.max(1L, (exp - now) / 1000L));
+            }
+        }
+
+        // --- lists ---
+        // Collect ordered values per key (sorted by idx), honouring expiry.
+        Map<String, List<String>> lists = new LinkedHashMap<>();
+        Map<String, Long> listExpiry = new HashMap<>();
+
+        List<Map<String, Object>> listRows = store.selectAll(LISTS_TABLE);
+        // Sort by idx within each key to preserve order.
+        listRows.sort((a, b) -> Long.compare(toLong(a.get("idx")), toLong(b.get("idx"))));
+        for (Map<String, Object> row : listRows) {
+            String key     = (String) row.get("key");
+            String value   = (String) row.get("value");
+            long expiresAt = toLong(row.get("expires_at"));
+            if (expiresAt > 0 && expiresAt <= now) continue;
+            lists.computeIfAbsent(key, k -> new ArrayList<>()).add(value);
+            if (expiresAt > 0) listExpiry.put(key, expiresAt);
+        }
+        for (Map.Entry<String, List<String>> entry : lists.entrySet()) {
+            String key = entry.getKey();
+            String[] vals = entry.getValue().toArray(new String[0]);
+            super.rpush(key, vals);
+            Long exp = listExpiry.get(key);
+            if (exp != null) super.expire(key, Math.max(1L, (exp - now) / 1000L));
+        }
+
+        // --- sets ---
+        Map<String, List<String>> sets = new LinkedHashMap<>();
+        Map<String, Long> setExpiry = new HashMap<>();
+
+        List<Map<String, Object>> setRows = store.selectAll(SETS_TABLE);
+        for (Map<String, Object> row : setRows) {
+            String key     = (String) row.get("key");
+            String member  = (String) row.get("member");
+            long expiresAt = toLong(row.get("expires_at"));
+            if (expiresAt > 0 && expiresAt <= now) continue;
+            sets.computeIfAbsent(key, k -> new ArrayList<>()).add(member);
+            if (expiresAt > 0) setExpiry.put(key, expiresAt);
+        }
+        for (Map.Entry<String, List<String>> entry : sets.entrySet()) {
+            String key = entry.getKey();
+            super.sadd(key, entry.getValue().toArray(new String[0]));
+            Long exp = setExpiry.get(key);
+            if (exp != null) super.expire(key, Math.max(1L, (exp - now) / 1000L));
+        }
+
+        // --- sorted sets ---
+        Map<String, Map<String, Double>> zsets = new LinkedHashMap<>();
+        Map<String, Long> zsetExpiry = new HashMap<>();
+
+        List<Map<String, Object>> zsetRows = store.selectAll(ZSETS_TABLE);
+        for (Map<String, Object> row : zsetRows) {
+            String key     = (String) row.get("key");
+            String member  = (String) row.get("member");
+            double score   = toDouble(row.get("score"));
+            long expiresAt = toLong(row.get("expires_at"));
+            if (expiresAt > 0 && expiresAt <= now) continue;
+            zsets.computeIfAbsent(key, k -> new LinkedHashMap<>()).put(member, score);
+            if (expiresAt > 0) zsetExpiry.put(key, expiresAt);
+        }
+        for (Map.Entry<String, Map<String, Double>> entry : zsets.entrySet()) {
+            String key = entry.getKey();
+            super.zadd(key, entry.getValue());
+            Long exp = zsetExpiry.get(key);
+            if (exp != null) super.expire(key, Math.max(1L, (exp - now) / 1000L));
+        }
+
+        // Clean up expired entries is handled by the background purge scheduler.
+    }
+
+    /**
+     * Deletes all expired entries from every store table.
+     * Called automatically at the end of {@link #warmUp()}; may also be called
+     * explicitly at any time (e.g. on a scheduled basis) to reclaim store space.
+     */
+    public void purgeExpired() throws SQLException {
+        long now = System.currentTimeMillis();
+
+        // strings — PK: key
+        for (Map<String, Object> row : store.selectAll(STRINGS_TABLE)) {
+            if (isExpired(row.get("expires_at"), now)) {
+                store.delete(STRINGS_TABLE, Map.of("key", row.get("key")));
+            }
+        }
+        // hashes — PK: (hash_key, field)
+        for (Map<String, Object> row : store.selectAll(HASHES_TABLE)) {
+            if (isExpired(row.get("expires_at"), now)) {
+                Map<String, Object> w = new HashMap<>();
+                w.put("hash_key", row.get("hash_key"));
+                w.put("field",    row.get("field"));
+                store.delete(HASHES_TABLE, w);
+            }
+        }
+        // lists — PK: (key, idx)
+        for (Map<String, Object> row : store.selectAll(LISTS_TABLE)) {
+            if (isExpired(row.get("expires_at"), now)) {
+                Map<String, Object> w = new HashMap<>();
+                w.put("key", row.get("key"));
+                w.put("idx", row.get("idx"));
+                store.delete(LISTS_TABLE, w);
+            }
+        }
+        // sets — PK: (key, member)
+        for (Map<String, Object> row : store.selectAll(SETS_TABLE)) {
+            if (isExpired(row.get("expires_at"), now)) {
+                Map<String, Object> w = new HashMap<>();
+                w.put("key",    row.get("key"));
+                w.put("member", row.get("member"));
+                store.delete(SETS_TABLE, w);
+            }
+        }
+        // zsets — PK: (key, member)
+        for (Map<String, Object> row : store.selectAll(ZSETS_TABLE)) {
+            if (isExpired(row.get("expires_at"), now)) {
+                Map<String, Object> w = new HashMap<>();
+                w.put("key",    row.get("key"));
+                w.put("member", row.get("member"));
+                store.delete(ZSETS_TABLE, w);
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // String commands
+    // -------------------------------------------------------------------------
+
+    @Override
+    public String set(final String key, final String value) {
+        try {
+            upsertString(key, value, 0L);
+        } catch (SQLException e) {
+            throw new JedisException("SyncLite store write failed for key: " + key, e);
+        }
+        return super.set(key, value);
+    }
+
+    @Override
+    public String setex(final String key, final long seconds, final String value) {
+        long expiresAt = System.currentTimeMillis() + seconds * 1_000L;
+        try {
+            upsertString(key, value, expiresAt);
+        } catch (SQLException e) {
+            throw new JedisException("SyncLite store setex failed for key: " + key, e);
+        }
+        return super.setex(key, seconds, value);
+    }
+
+    @Override
+    public String psetex(final String key, final long milliseconds, final String value) {
+        long expiresAt = System.currentTimeMillis() + milliseconds;
+        try {
+            upsertString(key, value, expiresAt);
+        } catch (SQLException e) {
+            throw new JedisException("SyncLite store psetex failed for key: " + key, e);
+        }
+        return super.psetex(key, milliseconds, value);
+    }
+
+    @Override
+    public String set(final String key, final String value, final SetParams params) {
+        // Resolve TTL from NX/XX/EX/PX/EXAT/PXAT params.
+        long expiresAt = resolveSetParamsExpiry(params);
+        try {
+            upsertString(key, value, expiresAt);
+        } catch (SQLException e) {
+            throw new JedisException("SyncLite store set failed for key: " + key, e);
+        }
+        return super.set(key, value, params);
+    }
+
+    @Override
+    public long setnx(final String key, final String value) {
+        try {
+            upsertString(key, value, 0L);
+        } catch (SQLException e) {
+            throw new JedisException("SyncLite store setnx failed for key: " + key, e);
+        }
+        return super.setnx(key, value);
+    }
+
+    @Override
+    public String mset(final String... keysvalues) {
+        try {
+            for (int i = 0; i < keysvalues.length - 1; i += 2) {
+                upsertString(keysvalues[i], keysvalues[i + 1], 0L);
+            }
+        } catch (SQLException e) {
+            throw new JedisException("SyncLite store mset failed", e);
+        }
+        return super.mset(keysvalues);
+    }
+
+    @Override
+    public long msetnx(final String... keysvalues) {
+        try {
+            for (int i = 0; i < keysvalues.length - 1; i += 2) {
+                upsertString(keysvalues[i], keysvalues[i + 1], 0L);
+            }
+        } catch (SQLException e) {
+            throw new JedisException("SyncLite store msetnx failed", e);
+        }
+        return super.msetnx(keysvalues);
+    }
+
+    @Override
+    public String getDel(final String key) {
+        try {
+            Map<String, Object> where = new HashMap<>();
+            where.put("key", key);
+            store.delete(STRINGS_TABLE, where);
+        } catch (SQLException e) {
+            throw new JedisException("SyncLite store getDel failed for key: " + key, e);
+        }
+        return super.getDel(key);
+    }
+
+    @Override
+    public String getSet(final String key, final String value) {
+        try {
+            upsertString(key, value, 0L);
+        } catch (SQLException e) {
+            throw new JedisException("SyncLite store getSet failed for key: " + key, e);
+        }
+        return super.getSet(key, value);
+    }
+
+    // -------------------------------------------------------------------------
+    // Key commands (del, expire)
+    // -------------------------------------------------------------------------
+
+    @Override
+    public long del(final String key) {
+        try {
+            deleteKey(key);
+        } catch (SQLException e) {
+            throw new JedisException("SyncLite store del failed for key: " + key, e);
+        }
+        return super.del(key);
+    }
+
+    @Override
+    public long del(final String... keys) {
+        try {
+            for (String key : keys) {
+                deleteKey(key);
+            }
+        } catch (SQLException e) {
+            throw new JedisException("SyncLite store del failed", e);
+        }
+        return super.del(keys);
+    }
+
+    @Override
+    public long expire(final String key, final long seconds) {
+        long expiresAt = System.currentTimeMillis() + seconds * 1_000L;
+        try {
+            Map<String, Object> setExp = new HashMap<>();
+            setExp.put("expires_at", expiresAt);
+
+            Map<String, Object> whereStr = new HashMap<>();
+            whereStr.put("key", key);
+            store.update(STRINGS_TABLE, setExp, whereStr);
+
+            Map<String, Object> whereHash = new HashMap<>();
+            whereHash.put("hash_key", key);
+            store.update(HASHES_TABLE, setExp, whereHash);
+
+            store.update(LISTS_TABLE, setExp, whereStr);
+            store.update(SETS_TABLE,  setExp, whereStr);
+
+            Map<String, Object> whereZset = new HashMap<>();
+            whereZset.put("key", key);
+            store.update(ZSETS_TABLE, setExp, whereZset);
+        } catch (SQLException e) {
+            throw new JedisException("SyncLite store expire failed for key: " + key, e);
+        }
+        return super.expire(key, seconds);
+    }
+
+    @Override
+    public long pexpire(final String key, final long milliseconds) {
+        long expiresAt = System.currentTimeMillis() + milliseconds;
+        try {
+            setExpiryAllTables(key, expiresAt);
+        } catch (SQLException e) {
+            throw new JedisException("SyncLite store pexpire failed for key: " + key, e);
+        }
+        return super.pexpire(key, milliseconds);
+    }
+
+    @Override
+    public long expireAt(final String key, final long unixTime) {
+        long expiresAt = unixTime * 1_000L;
+        try {
+            setExpiryAllTables(key, expiresAt);
+        } catch (SQLException e) {
+            throw new JedisException("SyncLite store expireAt failed for key: " + key, e);
+        }
+        return super.expireAt(key, unixTime);
+    }
+
+    @Override
+    public long pexpireAt(final String key, final long millisecondsTimestamp) {
+        try {
+            setExpiryAllTables(key, millisecondsTimestamp);
+        } catch (SQLException e) {
+            throw new JedisException("SyncLite store pexpireAt failed for key: " + key, e);
+        }
+        return super.pexpireAt(key, millisecondsTimestamp);
+    }
+
+    @Override
+    public long persist(final String key) {
+        try {
+            setExpiryAllTables(key, 0L);
+        } catch (SQLException e) {
+            throw new JedisException("SyncLite store persist failed for key: " + key, e);
+        }
+        return super.persist(key);
+    }
+
+    @Override
+    public long unlink(final String key) {
+        try {
+            deleteKey(key);
+        } catch (SQLException e) {
+            throw new JedisException("SyncLite store unlink failed for key: " + key, e);
+        }
+        return super.unlink(key);
+    }
+
+    @Override
+    public long unlink(final String... keys) {
+        try {
+            for (String key : keys) deleteKey(key);
+        } catch (SQLException e) {
+            throw new JedisException("SyncLite store unlink failed", e);
+        }
+        return super.unlink(keys);
+    }
+
+    @Override
+    public String rename(final String oldkey, final String newkey) {
+        try {
+            renameKey(oldkey, newkey);
+        } catch (SQLException e) {
+            throw new JedisException("SyncLite store rename failed for key: " + oldkey, e);
+        }
+        return super.rename(oldkey, newkey);
+    }
+
+    @Override
+    public long hset(final String key, final String field, final String value) {
+        try {
+            upsertHash(key, field, value, 0L);
+        } catch (SQLException e) {
+            throw new JedisException("SyncLite store hset failed for key: " + key + ", field: " + field, e);
+        }
+        return super.hset(key, field, value);
+    }
+
+    @Override
+    public long hset(final String key, final Map<String, String> hash) {
+        try {
+            for (Map.Entry<String, String> entry : hash.entrySet()) {
+                upsertHash(key, entry.getKey(), entry.getValue(), 0L);
+            }
+        } catch (SQLException e) {
+            throw new JedisException("SyncLite store hset failed for key: " + key, e);
+        }
+        return super.hset(key, hash);
+    }
+
+    @Override
+    public long hdel(final String key, final String... fields) {
+        try {
+            for (String field : fields) {
+                Map<String, Object> where = new HashMap<>();
+                where.put("hash_key", key);
+                where.put("field", field);
+                store.delete(HASHES_TABLE, where);
+            }
+        } catch (SQLException e) {
+            throw new JedisException("SyncLite store hdel failed for key: " + key, e);
+        }
+        return super.hdel(key, fields);
+    }
+
+    // -------------------------------------------------------------------------
+    // List commands
+    // -------------------------------------------------------------------------
+
+    @Override
+    public long rpush(final String key, final String... values) {
+        try {
+            appendListValues(key, values, false);
+        } catch (SQLException e) {
+            throw new JedisException("SyncLite store rpush failed for key: " + key, e);
+        }
+        return super.rpush(key, values);
+    }
+
+    @Override
+    public long lpush(final String key, final String... values) {
+        try {
+            // lpush prepends: for persistence, store the values in reverse order
+            // relative to existing capacity. We model the list by idx; prepend
+            // by inserting at negative indices before the current minimum.
+            appendListValues(key, values, true);
+        } catch (SQLException e) {
+            throw new JedisException("SyncLite store lpush failed for key: " + key, e);
+        }
+        return super.lpush(key, values);
+    }
+
+    @Override
+    public String lset(final String key, final long index, final String value) {
+        try {
+            Map<String, Object> where = new HashMap<>();
+            where.put("key", key);
+            where.put("idx", index);
+            store.delete(LISTS_TABLE, where);
+            Map<String, Object> row = new HashMap<>();
+            row.put("key",        key);
+            row.put("idx",        index);
+            row.put("value",      value);
+            row.put("expires_at", 0L);
+            store.insert(LISTS_TABLE, row);
+        } catch (SQLException e) {
+            throw new JedisException("SyncLite store lset failed for key: " + key, e);
+        }
+        return super.lset(key, index, value);
+    }
+
+    @Override
+    public long lpushx(final String key, final String... values) {
+        try {
+            if (!store.select(LISTS_TABLE, Map.of("key", key)).isEmpty()) {
+                appendListValues(key, values, true);
+            }
+        } catch (SQLException e) {
+            throw new JedisException("SyncLite store lpushx failed for key: " + key, e);
+        }
+        return super.lpushx(key, values);
+    }
+
+    @Override
+    public long rpushx(final String key, final String... values) {
+        try {
+            if (!store.select(LISTS_TABLE, Map.of("key", key)).isEmpty()) {
+                appendListValues(key, values, false);
+            }
+        } catch (SQLException e) {
+            throw new JedisException("SyncLite store rpushx failed for key: " + key, e);
+        }
+        return super.rpushx(key, values);
+    }
+
+    @Override
+    public String lpop(final String key) {
+        try {
+            removeListHead(key, 1);
+        } catch (SQLException e) {
+            throw new JedisException("SyncLite store lpop failed for key: " + key, e);
+        }
+        return super.lpop(key);
+    }
+
+    @Override
+    public List<String> lpop(final String key, final int count) {
+        try {
+            removeListHead(key, count);
+        } catch (SQLException e) {
+            throw new JedisException("SyncLite store lpop failed for key: " + key, e);
+        }
+        return super.lpop(key, count);
+    }
+
+    @Override
+    public String rpop(final String key) {
+        try {
+            removeListTail(key, 1);
+        } catch (SQLException e) {
+            throw new JedisException("SyncLite store rpop failed for key: " + key, e);
+        }
+        return super.rpop(key);
+    }
+
+    @Override
+    public List<String> rpop(final String key, final int count) {
+        try {
+            removeListTail(key, count);
+        } catch (SQLException e) {
+            throw new JedisException("SyncLite store rpop failed for key: " + key, e);
+        }
+        return super.rpop(key, count);
+    }
+
+    @Override
+    public long lrem(final String key, final long count, final String value) {
+        // Mirror Redis lrem semantics: count>0 remove from head, count<0 from tail,
+        // count=0 remove all. For store correctness we delete all matching rows;
+        // Redis handles the count-based direction itself.
+        try {
+            List<Map<String, Object>> rows = store.select(LISTS_TABLE, Map.of("key", key));
+            rows.sort(Comparator.comparingLong(r -> toLong(r.get("idx"))));
+            int limit = (count == 0) ? rows.size() : (int) Math.abs(count);
+            if (count < 0) java.util.Collections.reverse(rows);
+            int removed = 0;
+            for (Map<String, Object> row : rows) {
+                if (removed >= limit) break;
+                if (value.equals(row.get("value"))) {
+                    Map<String, Object> w = new HashMap<>();
+                    w.put("key", key);
+                    w.put("idx", row.get("idx"));
+                    store.delete(LISTS_TABLE, w);
+                    removed++;
+                }
+            }
+        } catch (SQLException e) {
+            throw new JedisException("SyncLite store lrem failed for key: " + key, e);
+        }
+        return super.lrem(key, count, value);
+    }
+
+    @Override
+    public String ltrim(final String key, final long start, final long end) {
+        try {
+            List<Map<String, Object>> rows = store.select(LISTS_TABLE, Map.of("key", key));
+            rows.sort(Comparator.comparingLong(r -> toLong(r.get("idx"))));
+            int size = rows.size();
+            long s = start < 0 ? Math.max(0, size + start) : start;
+            long e = end   < 0 ? size + end               : Math.min(end, size - 1L);
+            for (int i = 0; i < size; i++) {
+                if (i < s || i > e) {
+                    Map<String, Object> w = new HashMap<>();
+                    w.put("key", key);
+                    w.put("idx", rows.get(i).get("idx"));
+                    store.delete(LISTS_TABLE, w);
+                }
+            }
+        } catch (SQLException ex) {
+            throw new JedisException("SyncLite store ltrim failed for key: " + key, ex);
+        }
+        return super.ltrim(key, start, end);
+    }
+
+    @Override
+    public long sadd(final String key, final String... members) {
+        try {
+            for (String member : members) {
+                // Idempotent: delete then insert to avoid duplicates.
+                Map<String, Object> where = new HashMap<>();
+                where.put("key",    key);
+                where.put("member", member);
+                store.delete(SETS_TABLE, where);
+                Map<String, Object> row = new HashMap<>();
+                row.put("key",        key);
+                row.put("member",     member);
+                row.put("expires_at", 0L);
+                store.insert(SETS_TABLE, row);
+            }
+        } catch (SQLException e) {
+            throw new JedisException("SyncLite store sadd failed for key: " + key, e);
+        }
+        return super.sadd(key, members);
+    }
+
+    @Override
+    public long srem(final String key, final String... members) {
+        try {
+            for (String member : members) {
+                Map<String, Object> where = new HashMap<>();
+                where.put("key",    key);
+                where.put("member", member);
+                store.delete(SETS_TABLE, where);
+            }
+        } catch (SQLException e) {
+            throw new JedisException("SyncLite store srem failed for key: " + key, e);
+        }
+        return super.srem(key, members);
+    }
+
+    @Override
+    public String spop(final String key) {
+        String popped = super.spop(key);
+        if (popped != null) {
+            try {
+                Map<String, Object> w = new HashMap<>();
+                w.put("key",    key);
+                w.put("member", popped);
+                store.delete(SETS_TABLE, w);
+            } catch (SQLException e) {
+                throw new JedisException("SyncLite store spop failed for key: " + key, e);
+            }
+        }
+        return popped;
+    }
+
+    @Override
+    public Set<String> spop(final String key, final long count) {
+        Set<String> popped = super.spop(key, count);
+        if (popped != null) {
+            try {
+                for (String member : popped) {
+                    Map<String, Object> w = new HashMap<>();
+                    w.put("key",    key);
+                    w.put("member", member);
+                    store.delete(SETS_TABLE, w);
+                }
+            } catch (SQLException e) {
+                throw new JedisException("SyncLite store spop failed for key: " + key, e);
+            }
+        }
+        return popped;
+    }
+
+    @Override
+    public long smove(final String srckey, final String dstkey, final String member) {
+        try {
+            Map<String, Object> srcWhere = new HashMap<>();
+            srcWhere.put("key",    srckey);
+            srcWhere.put("member", member);
+            store.delete(SETS_TABLE, srcWhere);
+
+            Map<String, Object> dstRow = new HashMap<>();
+            dstRow.put("key",        dstkey);
+            dstRow.put("member",     member);
+            dstRow.put("expires_at", 0L);
+            // Idempotent: delete first in case member already exists in dst
+            store.delete(SETS_TABLE, Map.of("key", dstkey, "member", member));
+            store.insert(SETS_TABLE, dstRow);
+        } catch (SQLException e) {
+            throw new JedisException("SyncLite store smove failed for src: " + srckey, e);
+        }
+        return super.smove(srckey, dstkey, member);
+    }
+
+    @Override
+    public long zadd(final String key, final double score, final String member) {
+        try {
+            upsertZSet(key, member, score, 0L);
+        } catch (SQLException e) {
+            throw new JedisException("SyncLite store zadd failed for key: " + key, e);
+        }
+        return super.zadd(key, score, member);
+    }
+
+    @Override
+    public long zadd(final String key, final double score, final String member, final ZAddParams params) {
+        try {
+            upsertZSet(key, member, score, 0L);
+        } catch (SQLException e) {
+            throw new JedisException("SyncLite store zadd failed for key: " + key, e);
+        }
+        return super.zadd(key, score, member, params);
+    }
+
+    @Override
+    public long zadd(final String key, final Map<String, Double> scoreMembers) {
+        try {
+            for (Map.Entry<String, Double> e : scoreMembers.entrySet()) {
+                upsertZSet(key, e.getKey(), e.getValue(), 0L);
+            }
+        } catch (SQLException e) {
+            throw new JedisException("SyncLite store zadd failed for key: " + key, e);
+        }
+        return super.zadd(key, scoreMembers);
+    }
+
+    @Override
+    public long zadd(final String key, final Map<String, Double> scoreMembers, final ZAddParams params) {
+        try {
+            for (Map.Entry<String, Double> e : scoreMembers.entrySet()) {
+                upsertZSet(key, e.getKey(), e.getValue(), 0L);
+            }
+        } catch (SQLException e) {
+            throw new JedisException("SyncLite store zadd failed for key: " + key, e);
+        }
+        return super.zadd(key, scoreMembers, params);
+    }
+
+    @Override
+    public long zrem(final String key, final String... members) {
+        try {
+            for (String member : members) {
+                Map<String, Object> where = new HashMap<>();
+                where.put("key",    key);
+                where.put("member", member);
+                store.delete(ZSETS_TABLE, where);
+            }
+        } catch (SQLException e) {
+            throw new JedisException("SyncLite store zrem failed for key: " + key, e);
+        }
+        return super.zrem(key, members);
+    }
+
+    @Override
+    public double zincrby(final String key, final double increment, final String member) {
+        double newScore = super.zincrby(key, increment, member);
+        try {
+            upsertZSet(key, member, newScore, 0L);
+        } catch (SQLException e) {
+            throw new JedisException("SyncLite store zincrby failed for key: " + key, e);
+        }
+        return newScore;
+    }
+
+    @Override
+    public Tuple zpopmin(final String key) {
+        Tuple t = super.zpopmin(key);
+        if (t != null) {
+            try {
+                Map<String, Object> w = new HashMap<>();
+                w.put("key",    key);
+                w.put("member", t.getElement());
+                store.delete(ZSETS_TABLE, w);
+            } catch (SQLException e) {
+                throw new JedisException("SyncLite store zpopmin failed for key: " + key, e);
+            }
+        }
+        return t;
+    }
+
+    @Override
+    public List<Tuple> zpopmin(final String key, final int count) {
+        List<Tuple> tuples = super.zpopmin(key, count);
+        if (tuples != null) {
+            try {
+                for (Tuple t : tuples) {
+                    Map<String, Object> w = new HashMap<>();
+                    w.put("key",    key);
+                    w.put("member", t.getElement());
+                    store.delete(ZSETS_TABLE, w);
+                }
+            } catch (SQLException e) {
+                throw new JedisException("SyncLite store zpopmin failed for key: " + key, e);
+            }
+        }
+        return tuples;
+    }
+
+    @Override
+    public Tuple zpopmax(final String key) {
+        Tuple t = super.zpopmax(key);
+        if (t != null) {
+            try {
+                Map<String, Object> w = new HashMap<>();
+                w.put("key",    key);
+                w.put("member", t.getElement());
+                store.delete(ZSETS_TABLE, w);
+            } catch (SQLException e) {
+                throw new JedisException("SyncLite store zpopmax failed for key: " + key, e);
+            }
+        }
+        return t;
+    }
+
+    @Override
+    public List<Tuple> zpopmax(final String key, final int count) {
+        List<Tuple> tuples = super.zpopmax(key, count);
+        if (tuples != null) {
+            try {
+                for (Tuple t : tuples) {
+                    Map<String, Object> w = new HashMap<>();
+                    w.put("key",    key);
+                    w.put("member", t.getElement());
+                    store.delete(ZSETS_TABLE, w);
+                }
+            } catch (SQLException e) {
+                throw new JedisException("SyncLite store zpopmax failed for key: " + key, e);
+            }
+        }
+        return tuples;
+    }
+
+    // -------------------------------------------------------------------------
+    // Unsupported write operations
+    //
+    // These methods mutate Redis state in ways that cannot be durably mirrored
+    // to the SyncLite backing store.  Calling them always throws
+    // UnsupportedOperationException.
+    // -------------------------------------------------------------------------
+
+    // -- String in-place mutations --
+
+    @Override
+    public long append(final String key, final String value) {
+        throw new UnsupportedOperationException("SyncLite-backed Jedis does not support append");
+    }
+
+    @Override
+    public long setrange(final String key, final long offset, final String value) {
+        throw new UnsupportedOperationException("SyncLite-backed Jedis does not support setrange");
+    }
+
+    @Override
+    public long incr(final String key) {
+        throw new UnsupportedOperationException("SyncLite-backed Jedis does not support incr");
+    }
+
+    @Override
+    public long incrBy(final String key, final long increment) {
+        throw new UnsupportedOperationException("SyncLite-backed Jedis does not support incrBy");
+    }
+
+    @Override
+    public double incrByFloat(final String key, final double increment) {
+        throw new UnsupportedOperationException("SyncLite-backed Jedis does not support incrByFloat");
+    }
+
+    @Override
+    public long decr(final String key) {
+        throw new UnsupportedOperationException("SyncLite-backed Jedis does not support decr");
+    }
+
+    @Override
+    public long decrBy(final String key, final long decrement) {
+        throw new UnsupportedOperationException("SyncLite-backed Jedis does not support decrBy");
+    }
+
+    // -- Hash in-place mutations --
+
+    @Override
+    public long hsetnx(final String key, final String field, final String value) {
+        throw new UnsupportedOperationException("SyncLite-backed Jedis does not support hsetnx");
+    }
+
+    @Override
+    public long hincrBy(final String key, final String field, final long value) {
+        throw new UnsupportedOperationException("SyncLite-backed Jedis does not support hincrBy");
+    }
+
+    @Override
+    public double hincrByFloat(final String key, final String field, final double value) {
+        throw new UnsupportedOperationException("SyncLite-backed Jedis does not support hincrByFloat");
+    }
+
+    // -- List structural mutations --
+
+    @Override
+    public long linsert(final String key, final ListPosition where, final String pivot, final String value) {
+        throw new UnsupportedOperationException("SyncLite-backed Jedis does not support linsert");
+    }
+
+    @Override
+    public String lmove(final String srcKey, final String dstKey, final ListDirection from, final ListDirection to) {
+        throw new UnsupportedOperationException("SyncLite-backed Jedis does not support lmove");
+    }
+
+    @Override
+    public String blmove(final String srcKey, final String dstKey, final ListDirection from, final ListDirection to, final double timeout) {
+        throw new UnsupportedOperationException("SyncLite-backed Jedis does not support blmove");
+    }
+
+    @Override
+    public List<String> blpop(final int timeout, final String key) {
+        throw new UnsupportedOperationException("SyncLite-backed Jedis does not support blpop");
+    }
+
+    @Override
+    public List<String> blpop(final int timeout, final String... keys) {
+        throw new UnsupportedOperationException("SyncLite-backed Jedis does not support blpop");
+    }
+
+    @Override
+    public List<String> brpop(final int timeout, final String key) {
+        throw new UnsupportedOperationException("SyncLite-backed Jedis does not support brpop");
+    }
+
+    @Override
+    public List<String> brpop(final int timeout, final String... keys) {
+        throw new UnsupportedOperationException("SyncLite-backed Jedis does not support brpop");
+    }
+
+    // -- Set aggregation-store ops --
+
+    @Override
+    public long sunionstore(final String dstkey, final String... keys) {
+        throw new UnsupportedOperationException("SyncLite-backed Jedis does not support sunionstore");
+    }
+
+    @Override
+    public long sinterstore(final String dstkey, final String... keys) {
+        throw new UnsupportedOperationException("SyncLite-backed Jedis does not support sinterstore");
+    }
+
+    @Override
+    public long sdiffstore(final String dstkey, final String... keys) {
+        throw new UnsupportedOperationException("SyncLite-backed Jedis does not support sdiffstore");
+    }
+
+    // -- Sorted-set aggregation-store ops --
+
+    @Override
+    public long zdiffStore(final String dstKey, final String... keys) {
+        throw new UnsupportedOperationException("SyncLite-backed Jedis does not support zdiffStore");
+    }
+
+    @Override
+    public long zunionstore(final String dstKey, final String... keys) {
+        throw new UnsupportedOperationException("SyncLite-backed Jedis does not support zunionstore");
+    }
+
+    @Override
+    public long zunionstore(final String dstKey, final ZParams params, final String... keys) {
+        throw new UnsupportedOperationException("SyncLite-backed Jedis does not support zunionstore");
+    }
+
+    @Override
+    public long zinterstore(final String dstKey, final String... keys) {
+        throw new UnsupportedOperationException("SyncLite-backed Jedis does not support zinterstore");
+    }
+
+    @Override
+    public long zinterstore(final String dstKey, final ZParams params, final String... keys) {
+        throw new UnsupportedOperationException("SyncLite-backed Jedis does not support zinterstore");
+    }
+
+    @Override
+    public long zrangestore(final String dest, final String src, final ZRangeParams zRangeParams) {
+        throw new UnsupportedOperationException("SyncLite-backed Jedis does not support zrangestore");
+    }
+    // note: signature matches redis.clients.jedis.Jedis#zrangestore(String,String,ZRangeParams)
+
+    // -- Key ops that cannot be reconciled with the store --
+
+    @Override
+    public long renamenx(final String oldkey, final String newkey) {
+        throw new UnsupportedOperationException("SyncLite-backed Jedis does not support renamenx \u2014 use rename() instead");
+    }
+
+    @Override
+    public boolean copy(final String srcKey, final String dstKey, final boolean replace) {
+        throw new UnsupportedOperationException("SyncLite-backed Jedis does not support copy");
+    }
+
+    @Override
+    public boolean copy(final String srcKey, final String dstKey, final int db, final boolean replace) {
+        throw new UnsupportedOperationException("SyncLite-backed Jedis does not support copy");
+    }
+
+    @Override
+    public long move(final String key, final int dbIndex) {
+        throw new UnsupportedOperationException("SyncLite-backed Jedis does not support move");
+    }
+
+    @Override
+    public String restore(final String key, final long ttl, final byte[] serializedValue) {
+        throw new UnsupportedOperationException("SyncLite-backed Jedis does not support restore");
+    }
+
+    @Override
+    public long sort(final String key, final SortingParams sortingParameters, final String dstkey) {
+        throw new UnsupportedOperationException("SyncLite-backed Jedis does not support sort-with-store");
+    }
+
+    // -- Geo write ops --
+
+    @Override
+    public long geoadd(final String key, final double longitude, final double latitude, final String member) {
+        throw new UnsupportedOperationException("SyncLite-backed Jedis does not support geoadd");
+    }
+
+    @Override
+    public long geoadd(final String key, final Map<String, GeoCoordinate> memberCoordinateMap) {
+        throw new UnsupportedOperationException("SyncLite-backed Jedis does not support geoadd");
+    }
+
+    @Override
+    public long geoadd(final String key, final GeoAddParams params, final Map<String, GeoCoordinate> memberCoordinateMap) {
+        throw new UnsupportedOperationException("SyncLite-backed Jedis does not support geoadd");
+    }
+
+    // -- HyperLogLog write ops --
+
+    @Override
+    public long pfadd(final String key, final String... elements) {
+        throw new UnsupportedOperationException("SyncLite-backed Jedis does not support pfadd");
+    }
+
+    @Override
+    public String pfmerge(final String destkey, final String... sourcekeys) {
+        throw new UnsupportedOperationException("SyncLite-backed Jedis does not support pfmerge");
+    }
+
+    // -- Bitmap write ops --
+
+    @Override
+    public boolean setbit(final String key, final long offset, final boolean value) {
+        throw new UnsupportedOperationException("SyncLite-backed Jedis does not support setbit");
+    }
+
+    @Override
+    public long bitop(final BitOP op, final String destKey, final String... srcKeys) {
+        throw new UnsupportedOperationException("SyncLite-backed Jedis does not support bitop");
+    }
+
+    @Override
+    public List<Long> bitfield(final String key, final String... arguments) {
+        throw new UnsupportedOperationException("SyncLite-backed Jedis does not support bitfield");
+    }
+
+    // -- Stream write ops --
+
+    @Override
+    public StreamEntryID xadd(final String key, final StreamEntryID id, final Map<String, String> hash) {
+        throw new UnsupportedOperationException("SyncLite-backed Jedis does not support xadd");
+    }
+
+    @Override
+    public long xdel(final String key, final StreamEntryID... ids) {
+        throw new UnsupportedOperationException("SyncLite-backed Jedis does not support xdel");
+    }
+
+    @Override
+    public long xtrim(final String key, final long maxLen, final boolean approximate) {
+        throw new UnsupportedOperationException("SyncLite-backed Jedis does not support xtrim");
+    }
+
+    @Override
+    public long xack(final String key, final String group, final StreamEntryID... ids) {
+        throw new UnsupportedOperationException("SyncLite-backed Jedis does not support xack");
+    }
+
+    /**
+     * Closes the Redis connection and shuts down the background purge scheduler.
+     * The {@link SyncLiteStore} is <em>not</em> closed — its lifecycle is managed by the caller.
+     */
+    @Override
+    public void close() {
+        purgeScheduler.shutdownNow();
+        super.close();
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    private void upsertString(String key, String value, long expiresAt) throws SQLException {
+        Map<String, Object> where = new HashMap<>();
+        where.put("key", key);
+        store.delete(STRINGS_TABLE, where);
+
+        Map<String, Object> row = new HashMap<>();
+        row.put("key",        key);
+        row.put("value",      value);
+        row.put("expires_at", expiresAt);
+        store.insert(STRINGS_TABLE, row);
+    }
+
+    private void setExpiryAllTables(String key, long expiresAt) throws SQLException {
+        Map<String, Object> setExp = new HashMap<>();
+        setExp.put("expires_at", expiresAt);
+        Map<String, Object> byKey = new HashMap<>();
+        byKey.put("key", key);
+        store.update(STRINGS_TABLE, setExp, byKey);
+        store.update(LISTS_TABLE,   setExp, byKey);
+        store.update(SETS_TABLE,    setExp, byKey);
+        store.update(ZSETS_TABLE,   setExp, byKey);
+        Map<String, Object> byHashKey = new HashMap<>();
+        byHashKey.put("hash_key", key);
+        store.update(HASHES_TABLE, setExp, byHashKey);
+    }
+
+    private void renameKey(String oldkey, String newkey) throws SQLException {
+        // Strings
+        List<Map<String, Object>> strRows = store.select(STRINGS_TABLE, Map.of("key", oldkey));
+        if (!strRows.isEmpty()) {
+            store.delete(STRINGS_TABLE, Map.of("key", oldkey));
+            store.delete(STRINGS_TABLE, Map.of("key", newkey));
+            Map<String, Object> r = new HashMap<>(strRows.get(0));
+            r.put("key", newkey);
+            store.insert(STRINGS_TABLE, r);
+        }
+        // Hashes
+        List<Map<String, Object>> hashRows = store.select(HASHES_TABLE, Map.of("hash_key", oldkey));
+        if (!hashRows.isEmpty()) {
+            store.delete(HASHES_TABLE, Map.of("hash_key", newkey));
+            for (Map<String, Object> row : hashRows) {
+                store.delete(HASHES_TABLE, Map.of("hash_key", oldkey, "field", row.get("field")));
+                Map<String, Object> r = new HashMap<>(row);
+                r.put("hash_key", newkey);
+                store.insert(HASHES_TABLE, r);
+            }
+        }
+        // Lists
+        List<Map<String, Object>> listRows = store.select(LISTS_TABLE, Map.of("key", oldkey));
+        if (!listRows.isEmpty()) {
+            store.delete(LISTS_TABLE, Map.of("key", newkey));
+            for (Map<String, Object> row : listRows) {
+                store.delete(LISTS_TABLE, Map.of("key", oldkey, "idx", row.get("idx")));
+                Map<String, Object> r = new HashMap<>(row);
+                r.put("key", newkey);
+                store.insert(LISTS_TABLE, r);
+            }
+        }
+        // Sets
+        List<Map<String, Object>> setRows = store.select(SETS_TABLE, Map.of("key", oldkey));
+        if (!setRows.isEmpty()) {
+            store.delete(SETS_TABLE, Map.of("key", newkey));
+            for (Map<String, Object> row : setRows) {
+                store.delete(SETS_TABLE, Map.of("key", oldkey, "member", row.get("member")));
+                Map<String, Object> r = new HashMap<>(row);
+                r.put("key", newkey);
+                store.insert(SETS_TABLE, r);
+            }
+        }
+        // ZSets
+        List<Map<String, Object>> zsetRows = store.select(ZSETS_TABLE, Map.of("key", oldkey));
+        if (!zsetRows.isEmpty()) {
+            store.delete(ZSETS_TABLE, Map.of("key", newkey));
+            for (Map<String, Object> row : zsetRows) {
+                store.delete(ZSETS_TABLE, Map.of("key", oldkey, "member", row.get("member")));
+                Map<String, Object> r = new HashMap<>(row);
+                r.put("key", newkey);
+                store.insert(ZSETS_TABLE, r);
+            }
+        }
+    }
+
+    private void upsertHash(String hashKey, String field, String value, long expiresAt) throws SQLException {
+        Map<String, Object> where = new HashMap<>();
+        where.put("hash_key", hashKey);
+        where.put("field",    field);
+        store.delete(HASHES_TABLE, where);
+
+        Map<String, Object> row = new HashMap<>();
+        row.put("hash_key",   hashKey);
+        row.put("field",      field);
+        row.put("value",      value);
+        row.put("expires_at", expiresAt);
+        store.insert(HASHES_TABLE, row);
+    }
+
+    /**
+     * Deletes a key from all five store tables.
+     * Mirrors Redis {@code DEL} which removes any key type.
+     */
+    private void deleteKey(String key) throws SQLException {
+        Map<String, Object> byKey = new HashMap<>();
+        byKey.put("key", key);
+        store.delete(STRINGS_TABLE, byKey);
+        store.delete(LISTS_TABLE,   byKey);
+        store.delete(SETS_TABLE,    byKey);
+        store.delete(ZSETS_TABLE,   byKey);
+
+        Map<String, Object> hashWhere = new HashMap<>();
+        hashWhere.put("hash_key", key);
+        store.delete(HASHES_TABLE, hashWhere);
+    }
+
+    /**
+     * Appends list values to the store, assigning sequential idx values.
+     * If {@code prepend} is true the values are assigned descending indices
+     * below the current minimum (lpush semantics).
+     */
+    private void appendListValues(String key, String[] values, boolean prepend) throws SQLException {
+        List<Map<String, Object>> existing = store.select(LISTS_TABLE, Map.of("key", key));
+        long boundary;
+        if (existing.isEmpty()) {
+            boundary = prepend ? -1L : 0L;
+        } else {
+            if (prepend) {
+                boundary = existing.stream().mapToLong(r -> toLong(r.get("idx"))).min().getAsLong() - 1;
+            } else {
+                boundary = existing.stream().mapToLong(r -> toLong(r.get("idx"))).max().getAsLong() + 1;
+            }
+        }
+        for (String value : values) {
+            Map<String, Object> row = new HashMap<>();
+            row.put("key",        key);
+            row.put("idx",        boundary);
+            row.put("value",      value);
+            row.put("expires_at", 0L);
+            store.insert(LISTS_TABLE, row);
+            boundary += prepend ? -1L : 1L;
+        }
+    }
+
+    private void removeListHead(String key, int count) throws SQLException {
+        List<Map<String, Object>> rows = store.select(LISTS_TABLE, Map.of("key", key));
+        rows.sort(Comparator.comparingLong(r -> toLong(r.get("idx"))));
+        int limit = Math.min(count, rows.size());
+        for (int i = 0; i < limit; i++) {
+            Map<String, Object> w = new HashMap<>();
+            w.put("key", key);
+            w.put("idx", rows.get(i).get("idx"));
+            store.delete(LISTS_TABLE, w);
+        }
+    }
+
+    private void removeListTail(String key, int count) throws SQLException {
+        List<Map<String, Object>> rows = store.select(LISTS_TABLE, Map.of("key", key));
+        rows.sort(Comparator.comparingLong(r -> toLong(r.get("idx"))));
+        int size = rows.size();
+        int limit = Math.min(count, size);
+        for (int i = size - limit; i < size; i++) {
+            Map<String, Object> w = new HashMap<>();
+            w.put("key", key);
+            w.put("idx", rows.get(i).get("idx"));
+            store.delete(LISTS_TABLE, w);
+        }
+    }
+
+    private void upsertZSet(String key, String member, double score, long expiresAt) throws SQLException {
+        Map<String, Object> where = new HashMap<>();
+        where.put("key",    key);
+        where.put("member", member);
+        store.delete(ZSETS_TABLE, where);
+
+        Map<String, Object> row = new HashMap<>();
+        row.put("key",        key);
+        row.put("score",      score);
+        row.put("member",     member);
+        row.put("expires_at", expiresAt);
+        store.insert(ZSETS_TABLE, row);
+    }
+
+    private static long toLong(Object o) {
+        if (o == null) return 0L;
+        return ((Number) o).longValue();
+    }
+
+    private static double toDouble(Object o) {
+        if (o == null) return 0.0;
+        return ((Number) o).doubleValue();
+    }
+
+    private static boolean isExpired(Object expiresAtObj, long now) {
+        long exp = toLong(expiresAtObj);
+        return exp > 0 && exp <= now;
+    }
+
+    private static long resolveSetParamsExpiry(SetParams params) {
+        if (params == null) return 0L;
+        try {
+            // SetParams stores values under the Redis keyword keys (ex, px, exat, pxat).
+            // The inherited getParam(String) method retrieves them directly, avoiding
+            // any dependency on toString() format which varies across Jedis versions.
+            Object pxat = params.getParam("pxat");
+            if (pxat != null) return toLong(pxat);
+
+            Object exat = params.getParam("exat");
+            if (exat != null) return toLong(exat) * 1_000L;
+
+            Object px = params.getParam("px");
+            if (px != null) return System.currentTimeMillis() + toLong(px);
+
+            Object ex = params.getParam("ex");
+            if (ex != null) return System.currentTimeMillis() + toLong(ex) * 1_000L;
+        } catch (Exception ignored) {}
+        return 0L;
+    }
+}

--- a/logger/src/test/java/io/synclite/logger/JedisTest.java
+++ b/logger/src/test/java/io/synclite/logger/JedisTest.java
@@ -1,0 +1,929 @@
+/*
+ * Copyright (c) 2024 mahendra.chavan@synclite.io, all rights reserved.
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.  See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.synclite.logger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.github.fppt.jedismock.RedisServer;
+
+/**
+ * Integration test for {@link Jedis}.
+ *
+ * <p>Uses an in-process {@link RedisServer} (jedis-mock) so no external Redis
+ * installation or Docker daemon is required.  The mock server is started once
+ * for the whole test class and flushed between individual tests.
+ */
+class JedisTest {
+
+    private static RedisServer mockRedis;
+    private static String      redisHost;
+    private static int         redisPort;
+
+    @BeforeAll
+    static void startMockRedis() throws Exception {
+        mockRedis = RedisServer.newRedisServer();
+        mockRedis.start();
+        redisHost = mockRedis.getHost();
+        redisPort = mockRedis.getBindPort();
+    }
+
+    @AfterAll
+    static void stopMockRedis() throws Exception {
+        if (mockRedis != null) {
+            mockRedis.stop();
+        }
+    }
+
+    private Path testDbPath;
+    private Path testStageDir;
+    private SyncLiteStore store;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        // Flush any state left by the previous test.
+        try (redis.clients.jedis.Jedis flush = new redis.clients.jedis.Jedis(redisHost, redisPort)) {
+            flush.flushAll();
+        }
+
+        Path testHome = Path.of(System.getProperty("user.home"))
+                .resolve("synclite").resolve("test").resolve("JedisTest");
+        testDbPath   = testHome.resolve("db").resolve("test.db");
+        testStageDir = testHome.resolve("stageDir");
+
+        if (Files.exists(testHome)) {
+            deleteRecursively(testHome);
+        }
+        Files.createDirectories(testDbPath.getParent());
+        Files.createDirectories(testStageDir);
+
+        Path configPath = testHome.resolve("synclite_logger.conf");
+        Files.writeString(configPath,
+                "local-data-stage-directory = " + testStageDir + "\ndestination-type = FS\n");
+
+        Class.forName("io.synclite.logger.SQLiteStore");
+        SQLiteStore.initialize(testDbPath, configPath, "jedistest");
+        store = SQLiteStore.open(testDbPath);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (store != null) {
+            store.close();
+            store = null;
+        }
+        SQLiteStore.closeAllDevices();
+        Thread.sleep(150);
+    }
+
+    // -------------------------------------------------------------------------
+    // Tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testSetAndGet() throws Exception {
+        try (Jedis jedis = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
+            jedis.set("k1", "v1");
+            jedis.set("k2", "v2");
+
+            // Redis returns the value
+            assertEquals("v1", jedis.get("k1"));
+            assertEquals("v2", jedis.get("k2"));
+
+            // Store has both rows
+            List<Map<String, Object>> rows = store.selectAll(Jedis.STRINGS_TABLE);
+            assertEquals(2, rows.size());
+
+            List<Map<String, Object>> k1Rows = store.select(Jedis.STRINGS_TABLE, Map.of("key", "k1"));
+            assertEquals(1, k1Rows.size());
+            assertEquals("v1", k1Rows.get(0).get("value"));
+        }
+    }
+
+    @Test
+    void testSetOverwritesExistingKey() throws Exception {
+        try (Jedis jedis = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
+            jedis.set("k1", "original");
+            jedis.set("k1", "updated");
+
+            assertEquals("updated", jedis.get("k1"));
+
+            // Only one row in the store for k1
+            List<Map<String, Object>> k1Rows = store.select(Jedis.STRINGS_TABLE, Map.of("key", "k1"));
+            assertEquals(1, k1Rows.size());
+            assertEquals("updated", k1Rows.get(0).get("value"));
+        }
+    }
+
+    @Test
+    void testDel() throws Exception {
+        try (Jedis jedis = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
+            jedis.set("k1", "v1");
+            jedis.set("k2", "v2");
+
+            jedis.del("k1");
+
+            assertNull(jedis.get("k1"), "Deleted key should return null from Redis");
+            assertEquals("v2", jedis.get("k2"));
+
+            // k1 gone from store; k2 still present
+            assertEquals(0, store.select(Jedis.STRINGS_TABLE, Map.of("key", "k1")).size());
+            assertEquals(1, store.select(Jedis.STRINGS_TABLE, Map.of("key", "k2")).size());
+        }
+    }
+
+    @Test
+    void testMultiKeyDel() throws Exception {
+        try (Jedis jedis = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
+            jedis.set("k1", "v1");
+            jedis.set("k2", "v2");
+            jedis.set("k3", "v3");
+
+            jedis.del("k1", "k3");
+
+            assertNull(jedis.get("k1"));
+            assertNull(jedis.get("k3"));
+            assertEquals("v2", jedis.get("k2"));
+
+            assertEquals(1, store.selectAll(Jedis.STRINGS_TABLE).size());
+        }
+    }
+
+    @Test
+    void testHsetAndHget() throws Exception {
+        try (Jedis jedis = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
+            jedis.hset("user:1", "name", "Alice");
+            jedis.hset("user:1", "email", "alice@example.com");
+
+            assertEquals("Alice",              jedis.hget("user:1", "name"));
+            assertEquals("alice@example.com",  jedis.hget("user:1", "email"));
+
+            // Store has two rows for hash user:1
+            List<Map<String, Object>> hashRows = store.selectAll(Jedis.HASHES_TABLE);
+            assertEquals(2, hashRows.size());
+        }
+    }
+
+    @Test
+    void testHsetMap() throws Exception {
+        try (Jedis jedis = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
+            jedis.hset("session:42", Map.of("token", "abc123", "user", "bob"));
+
+            assertEquals("abc123", jedis.hget("session:42", "token"));
+            assertEquals("bob",    jedis.hget("session:42", "user"));
+
+            assertEquals(2, store.select(Jedis.HASHES_TABLE, Map.of("hash_key", "session:42")).size());
+        }
+    }
+
+    @Test
+    void testHdel() throws Exception {
+        try (Jedis jedis = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
+            jedis.hset("user:1", "name", "Alice");
+            jedis.hset("user:1", "age", "30");
+
+            jedis.hdel("user:1", "age");
+
+            assertNull(jedis.hget("user:1", "age"), "Deleted hash field should be null");
+            assertEquals("Alice", jedis.hget("user:1", "name"), "Other fields unaffected");
+
+            // Only name left in store
+            List<Map<String, Object>> remaining = store.select(Jedis.HASHES_TABLE, Map.of("hash_key", "user:1"));
+            assertEquals(1, remaining.size());
+            assertEquals("name", remaining.get(0).get("field"));
+        }
+    }
+
+    @Test
+    void testDelRemovesHashEntries() throws Exception {
+        try (Jedis jedis = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
+            jedis.hset("user:1", "name", "Alice");
+            jedis.hset("user:1", "role", "admin");
+
+            jedis.del("user:1");
+
+            // All hash rows for user:1 removed from store
+            assertEquals(0, store.select(Jedis.HASHES_TABLE, Map.of("hash_key", "user:1")).size());
+        }
+    }
+
+    @Test
+    void testWarmUpRebuildsCacheFromStore() throws Exception {
+        // Phase 1 — write data through Jedis so it lands in the store
+        try (Jedis jedis1 = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
+            jedis1.set("rebuild:str", "hello");
+            jedis1.hset("rebuild:hash", "field1", "world");
+        }
+
+        // Phase 2 — manually clear Redis (simulate a restart) using a raw Jedis client
+        // that goes directly to Redis without touching the store.
+        try (redis.clients.jedis.Jedis raw = new redis.clients.jedis.Jedis(redisHost, redisPort)) {
+            raw.del("rebuild:str");
+            raw.del("rebuild:hash");
+            assertNull(raw.get("rebuild:str"),           "Redis should be empty after manual del");
+            assertNull(raw.hget("rebuild:hash", "field1"), "Redis should be empty after manual del");
+        }
+
+        // Phase 3 — create a new Jedis instance; warmUp() should restore from store
+        try (Jedis jedis2 = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
+            assertEquals("hello", jedis2.get("rebuild:str"),            "warmUp should restore string key");
+            assertEquals("world", jedis2.hget("rebuild:hash", "field1"), "warmUp should restore hash field");
+        }
+    }
+
+    /**
+     * The core SyncLite-Jedis guarantee: after a full process restart —
+     * store closed, Redis wiped — opening the same persisted store and
+     * constructing a new {@link Jedis} instance must restore all five Redis
+     * data types back into the (now-empty) cache via {@link Jedis#warmUp()}.
+     *
+     * <p>Test flow:
+     * <ol>
+     *   <li><b>Phase 1 – running:</b> write strings, hashes, lists, sets and
+     *       sorted sets through the SyncLite Jedis.  Data lands in both Redis
+     *       and the backing SQLite store.</li>
+     *   <li><b>Phase 2 – shutdown:</b> close the store and call
+     *       {@code closeAllDevices()} exactly as an application shutdown would.</li>
+     *   <li><b>Phase 3 – Redis gone:</b> flush the entire Redis cache, simulating
+     *       a Redis server restart or eviction.</li>
+     *   <li><b>Phase 4 – restart:</b> re-open the <em>same</em> store DB
+     *       (no {@code initialize()} call — the data already exists in the file)
+     *       and build a new {@code Jedis} instance.  The constructor calls
+     *       {@code warmUp()} which must reload every key into Redis.</li>
+     *   <li><b>Assertions:</b> all five data types are verified to be present
+     *       and correct in Redis using only Redis-side reads.</li>
+     * </ol>
+     */
+    @Test
+    void testRestartReloadsAllTypesFromStore() throws Exception {
+        // ── Phase 1: running ────────────────────────────────────────────────
+        try (Jedis jedis1 = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
+            // Strings
+            jedis1.set("rs:str",  "hello");
+            jedis1.setex("rs:str:ttl", 3600L, "withttl");
+            // Hash
+            jedis1.hset("rs:hash", Map.of("field1", "v1", "field2", "v2"));
+            // List — rpush so order is a, b, c
+            jedis1.rpush("rs:list", "a", "b", "c");
+            // Set
+            jedis1.sadd("rs:set", "x", "y", "z");
+            // Sorted set — low-to-high scores so zrange returns gold, silver, bronze
+            jedis1.zadd("rs:zset", Map.of("gold", 1.0, "silver", 2.0, "bronze", 3.0));
+        }
+
+        // ── Phase 2: application shutdown ───────────────────────────────────
+        store.close();
+        store = null;
+        SQLiteStore.closeAllDevices();
+        Thread.sleep(200); // let Windows release any file handles
+
+        // ── Phase 3: Redis restart (full cache wipe) ─────────────────────────
+        try (redis.clients.jedis.Jedis raw = new redis.clients.jedis.Jedis(redisHost, redisPort)) {
+            raw.flushAll();
+            // Confirm everything is gone before we recreate the Jedis instance
+            assertNull(raw.get("rs:str"),                          "cache should be empty after flushAll");
+            assertTrue(raw.hgetAll("rs:hash").isEmpty(),           "cache should be empty after flushAll");
+            assertTrue(raw.lrange("rs:list", 0, -1).isEmpty(),    "cache should be empty after flushAll");
+            assertTrue(raw.smembers("rs:set").isEmpty(),          "cache should be empty after flushAll");
+            assertTrue(raw.zrange("rs:zset", 0, -1).isEmpty(),    "cache should be empty after flushAll");
+        }
+
+        // ── Phase 4: application restart ─────────────────────────────────────
+        // Re-open the existing store DB — no initialize(), data already there.
+        SyncLiteStore restartedStore = SQLiteStore.open(testDbPath);
+        try (Jedis jedis2 = Jedis.builder(restartedStore).host(redisHost).port(redisPort).build()) {
+            // warmUp() executed inside the constructor — assert Redis is fully rebuilt
+
+            // Strings
+            assertEquals("hello",   jedis2.get("rs:str"),           "String key restored after restart");
+            assertEquals("withttl", jedis2.get("rs:str:ttl"),       "TTL string key restored after restart");
+
+            // Hash
+            assertEquals("v1",      jedis2.hget("rs:hash", "field1"), "Hash field1 restored");
+            assertEquals("v2",      jedis2.hget("rs:hash", "field2"), "Hash field2 restored");
+
+            // List — order must be preserved
+            assertEquals(List.of("a", "b", "c"),
+                    jedis2.lrange("rs:list", 0, -1),             "List restored in insertion order");
+
+            // Set — all members present (order is undefined for sets)
+            Set<String> restoredSet = jedis2.smembers("rs:set");
+            assertTrue(restoredSet.containsAll(Set.of("x", "y", "z")), "All set members restored");
+
+            // Sorted set — zrange returns members in ascending score order
+            assertEquals(List.of("gold", "silver", "bronze"),
+                    jedis2.zrange("rs:zset", 0, -1),             "ZSet restored in score order");
+        } finally {
+            restartedStore.close();
+            // tearDown will call closeAllDevices(); store is already null so nothing double-closed
+        }
+    }
+
+    @Test
+    void testSetex() throws Exception {
+        try (Jedis jedis = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
+            jedis.setex("ttl:key", 3600L, "ttlvalue");
+
+            assertEquals("ttlvalue", jedis.get("ttl:key"));
+
+            List<Map<String, Object>> rows = store.select(Jedis.STRINGS_TABLE, Map.of("key", "ttl:key"));
+            assertEquals(1, rows.size());
+            long expiresAt = ((Number) rows.get(0).get("expires_at")).longValue();
+            assertTrue(expiresAt > System.currentTimeMillis(), "expires_at should be in the future");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // List tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testRpushAndListStore() throws Exception {
+        try (Jedis jedis = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
+            jedis.rpush("mylist", "a", "b", "c");
+
+            // Redis holds the list
+            List<String> redisValues = jedis.lrange("mylist", 0, -1);
+            assertEquals(List.of("a", "b", "c"), redisValues);
+
+            // Store has 3 rows for mylist
+            List<Map<String, Object>> rows = store.select(Jedis.LISTS_TABLE, Map.of("key", "mylist"));
+            assertEquals(3, rows.size());
+        }
+    }
+
+    @Test
+    void testLpush() throws Exception {
+        try (Jedis jedis = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
+            jedis.rpush("llist", "x");
+            jedis.lpush("llist", "y");      // y is now head
+
+            List<String> redisValues = jedis.lrange("llist", 0, -1);
+            assertEquals("y", redisValues.get(0), "lpush value should be at the head");
+
+            // 2 rows in store
+            assertEquals(2, store.select(Jedis.LISTS_TABLE, Map.of("key", "llist")).size());
+        }
+    }
+
+    @Test
+    void testListWarmUp() throws Exception {
+        try (Jedis jedis1 = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
+            jedis1.rpush("wlist", "p", "q", "r");
+        }
+
+        // Clear Redis
+        try (redis.clients.jedis.Jedis raw = new redis.clients.jedis.Jedis(redisHost, redisPort)) {
+            raw.del("wlist");
+        }
+
+        try (Jedis jedis2 = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
+            List<String> restored = jedis2.lrange("wlist", 0, -1);
+            assertEquals(List.of("p", "q", "r"), restored, "warmUp should restore list in order");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Set tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testSaddAndSrem() throws Exception {
+        try (Jedis jedis = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
+            jedis.sadd("tags", "java", "redis", "synclite");
+
+            Set<String> members = jedis.smembers("tags");
+            assertTrue(members.contains("java"));
+            assertTrue(members.contains("redis"));
+            assertTrue(members.contains("synclite"));
+
+            // 3 rows in store
+            assertEquals(3, store.select(Jedis.SETS_TABLE, Map.of("key", "tags")).size());
+
+            jedis.srem("tags", "redis");
+            assertFalse(jedis.smembers("tags").contains("redis"));
+            assertEquals(2, store.select(Jedis.SETS_TABLE, Map.of("key", "tags")).size());
+        }
+    }
+
+    @Test
+    void testSetWarmUp() throws Exception {
+        try (Jedis jedis1 = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
+            jedis1.sadd("colors", "red", "green", "blue");
+        }
+
+        try (redis.clients.jedis.Jedis raw = new redis.clients.jedis.Jedis(redisHost, redisPort)) {
+            raw.del("colors");
+        }
+
+        try (Jedis jedis2 = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
+            Set<String> restored = jedis2.smembers("colors");
+            assertTrue(restored.containsAll(Set.of("red", "green", "blue")), "warmUp should restore set members");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Sorted set tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testZaddAndZrem() throws Exception {
+        try (Jedis jedis = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
+            jedis.zadd("scores", 10.0, "alice");
+            jedis.zadd("scores", 20.0, "bob");
+            jedis.zadd("scores", 15.0, "carol");
+
+            // Redis sorted by score
+            List<String> byScore = jedis.zrange("scores", 0, -1);
+            assertEquals(List.of("alice", "carol", "bob"), byScore);
+
+            // 3 rows in store
+            assertEquals(3, store.select(Jedis.ZSETS_TABLE, Map.of("key", "scores")).size());
+
+            jedis.zrem("scores", "carol");
+            assertEquals(2, store.select(Jedis.ZSETS_TABLE, Map.of("key", "scores")).size());
+        }
+    }
+
+    @Test
+    void testZaddMap() throws Exception {
+        try (Jedis jedis = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
+            jedis.zadd("leaderboard", Map.of("player1", 100.0, "player2", 200.0));
+
+            assertEquals(2, store.select(Jedis.ZSETS_TABLE, Map.of("key", "leaderboard")).size());
+            assertTrue(jedis.zscore("leaderboard", "player1") == 100.0);
+        }
+    }
+
+    @Test
+    void testZSetWarmUp() throws Exception {
+        try (Jedis jedis1 = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
+            jedis1.zadd("ranking", 1.0, "gold");
+            jedis1.zadd("ranking", 2.0, "silver");
+            jedis1.zadd("ranking", 3.0, "bronze");
+        }
+
+        try (redis.clients.jedis.Jedis raw = new redis.clients.jedis.Jedis(redisHost, redisPort)) {
+            raw.del("ranking");
+        }
+
+        try (Jedis jedis2 = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
+            List<String> restored = jedis2.zrange("ranking", 0, -1);
+            assertEquals(List.of("gold", "silver", "bronze"), restored, "warmUp should restore sorted set in score order");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // String extended ops
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testSetnx() throws Exception {
+        try (Jedis jedis = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
+            long r1 = jedis.setnx("nx:key", "first");
+            long r2 = jedis.setnx("nx:key", "second");
+
+            // Redis reports 1 for new, 0 for existing
+            assertEquals(1L, r1);
+            assertEquals(0L, r2);
+
+            // Store was overwritten by our setnx impl (store-first write)
+            List<Map<String, Object>> rows = store.select(Jedis.STRINGS_TABLE, Map.of("key", "nx:key"));
+            assertEquals(1, rows.size());
+        }
+    }
+
+    @Test
+    void testMset() throws Exception {
+        try (Jedis jedis = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
+            jedis.mset("m1", "v1", "m2", "v2", "m3", "v3");
+
+            assertEquals("v1", jedis.get("m1"));
+            assertEquals("v2", jedis.get("m2"));
+            assertEquals("v3", jedis.get("m3"));
+
+            assertEquals(3, store.selectAll(Jedis.STRINGS_TABLE).size());
+        }
+    }
+
+    @Test
+    void testGetDel() throws Exception {
+        try (Jedis jedis = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
+            jedis.set("gd:key", "gone");
+
+            String value = jedis.getDel("gd:key");
+
+            assertEquals("gone", value);
+            // Removed from store
+            assertEquals(0, store.select(Jedis.STRINGS_TABLE, Map.of("key", "gd:key")).size());
+            assertNull(jedis.get("gd:key"));
+        }
+    }
+
+    @Test
+    void testGetSet() throws Exception {
+        try (Jedis jedis = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
+            jedis.set("gs:key", "original");
+            String old = jedis.getSet("gs:key", "updated");
+
+            assertEquals("original", old);
+            assertEquals("updated",  jedis.get("gs:key"));
+
+            List<Map<String, Object>> rows = store.select(Jedis.STRINGS_TABLE, Map.of("key", "gs:key"));
+            assertEquals("updated", rows.get(0).get("value"));
+        }
+    }
+
+    @Test
+    void testSetWithSetParams() throws Exception {
+        try (Jedis jedis = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
+            jedis.set("sp:key", "spvalue", redis.clients.jedis.params.SetParams.setParams().ex(3600));
+
+            assertEquals("spvalue", jedis.get("sp:key"));
+
+            List<Map<String, Object>> rows = store.select(Jedis.STRINGS_TABLE, Map.of("key", "sp:key"));
+            assertEquals(1, rows.size());
+            long expiresAt = ((Number) rows.get(0).get("expires_at")).longValue();
+            assertTrue(expiresAt > System.currentTimeMillis(), "expires_at should be in the future for EX param");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Key expiry / lifecycle extended ops
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testPexpire() throws Exception {
+        try (Jedis jedis = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
+            jedis.set("px:key", "val");
+            jedis.pexpire("px:key", 3_600_000L); // 1 hour in ms
+
+            List<Map<String, Object>> rows = store.select(Jedis.STRINGS_TABLE, Map.of("key", "px:key"));
+            long expiresAt = ((Number) rows.get(0).get("expires_at")).longValue();
+            assertTrue(expiresAt > System.currentTimeMillis());
+        }
+    }
+
+    @Test
+    void testExpireAt() throws Exception {
+        try (Jedis jedis = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
+            jedis.set("eat:key", "val");
+            long futureUnix = System.currentTimeMillis() / 1000L + 3600L;
+            jedis.expireAt("eat:key", futureUnix);
+
+            List<Map<String, Object>> rows = store.select(Jedis.STRINGS_TABLE, Map.of("key", "eat:key"));
+            long expiresAt = ((Number) rows.get(0).get("expires_at")).longValue();
+            assertEquals(futureUnix * 1000L, expiresAt);
+        }
+    }
+
+    @Test
+    void testPersist() throws Exception {
+        try (Jedis jedis = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
+            jedis.setex("persist:key", 3600L, "val");
+
+            List<Map<String, Object>> before = store.select(Jedis.STRINGS_TABLE, Map.of("key", "persist:key"));
+            assertTrue(((Number) before.get(0).get("expires_at")).longValue() > 0);
+
+            jedis.persist("persist:key");
+
+            List<Map<String, Object>> after = store.select(Jedis.STRINGS_TABLE, Map.of("key", "persist:key"));
+            assertEquals(0L, ((Number) after.get(0).get("expires_at")).longValue());
+        }
+    }
+
+    @Test
+    void testUnlink() throws Exception {
+        try (Jedis jedis = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
+            jedis.set("ul:k1", "v1");
+            jedis.set("ul:k2", "v2");
+
+            jedis.unlink("ul:k1");
+
+            assertNull(jedis.get("ul:k1"));
+            assertEquals(0, store.select(Jedis.STRINGS_TABLE, Map.of("key", "ul:k1")).size());
+            assertEquals(1, store.select(Jedis.STRINGS_TABLE, Map.of("key", "ul:k2")).size());
+        }
+    }
+
+    @Test
+    void testRename() throws Exception {
+        try (Jedis jedis = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
+            jedis.set("rn:old", "myvalue");
+
+            jedis.rename("rn:old", "rn:new");
+
+            assertEquals("myvalue", jedis.get("rn:new"));
+            assertNull(jedis.get("rn:old"));
+
+            assertEquals(0, store.select(Jedis.STRINGS_TABLE, Map.of("key", "rn:old")).size());
+            assertEquals(1, store.select(Jedis.STRINGS_TABLE, Map.of("key", "rn:new")).size());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // List extended ops
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testLpushx() throws Exception {
+        try (Jedis jedis = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
+            // Key does not exist — lpushx should be a no-op in the store
+            jedis.lpushx("lpx:list", "nowrite");
+
+            assertEquals(0, store.select(Jedis.LISTS_TABLE, Map.of("key", "lpx:list")).size());
+
+            // Create the key, then lpushx should write
+            jedis.rpush("lpx:list", "base");
+            jedis.lpushx("lpx:list", "head");
+
+            assertEquals(2, store.select(Jedis.LISTS_TABLE, Map.of("key", "lpx:list")).size());
+            assertEquals("head", jedis.lrange("lpx:list", 0, -1).get(0));
+        }
+    }
+
+    @Test
+    void testRpushx() throws Exception {
+        try (Jedis jedis = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
+            jedis.rpushx("rpx:list", "nowrite");
+            assertEquals(0, store.select(Jedis.LISTS_TABLE, Map.of("key", "rpx:list")).size());
+
+            jedis.rpush("rpx:list", "base");
+            jedis.rpushx("rpx:list", "tail");
+
+            assertEquals(2, store.select(Jedis.LISTS_TABLE, Map.of("key", "rpx:list")).size());
+            List<String> vals = jedis.lrange("rpx:list", 0, -1);
+            assertEquals("tail", vals.get(vals.size() - 1));
+        }
+    }
+
+    @Test
+    void testLpop() throws Exception {
+        try (Jedis jedis = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
+            jedis.rpush("pop:list", "a", "b", "c");
+
+            String head = jedis.lpop("pop:list");
+            assertEquals("a", head);
+
+            // 2 elements left in store
+            assertEquals(2, store.select(Jedis.LISTS_TABLE, Map.of("key", "pop:list")).size());
+        }
+    }
+
+    @Test
+    void testRpop() throws Exception {
+        try (Jedis jedis = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
+            jedis.rpush("rpop:list", "x", "y", "z");
+
+            String tail = jedis.rpop("rpop:list");
+            assertEquals("z", tail);
+
+            assertEquals(2, store.select(Jedis.LISTS_TABLE, Map.of("key", "rpop:list")).size());
+        }
+    }
+
+    @Test
+    void testLrem() throws Exception {
+        try (Jedis jedis = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
+            jedis.rpush("lrem:list", "a", "b", "a", "c", "a");
+
+            // Remove 2 occurrences of "a" from head
+            jedis.lrem("lrem:list", 2, "a");
+
+            List<Map<String, Object>> rows = store.select(Jedis.LISTS_TABLE, Map.of("key", "lrem:list"));
+            long aCount = rows.stream().filter(r -> "a".equals(r.get("value"))).count();
+            assertTrue(aCount <= 1, "At most 1 'a' should remain in the store after lrem count=2");
+        }
+    }
+
+    @Test
+    void testLtrim() throws Exception {
+        try (Jedis jedis = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
+            jedis.rpush("lt:list", "a", "b", "c", "d", "e");
+
+            jedis.ltrim("lt:list", 1, 3);
+
+            // Only 3 elements should remain (indices 1-3: b, c, d)
+            assertEquals(3, store.select(Jedis.LISTS_TABLE, Map.of("key", "lt:list")).size());
+
+            List<String> trimmed = jedis.lrange("lt:list", 0, -1);
+            assertEquals(List.of("b", "c", "d"), trimmed);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Set extended ops
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testSpop() throws Exception {
+        try (Jedis jedis = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
+            jedis.sadd("sp:set", "x", "y", "z");
+
+            String popped = jedis.spop("sp:set");
+            assertNotNull(popped);
+
+            // 2 members left in store
+            List<Map<String, Object>> rows = store.select(Jedis.SETS_TABLE, Map.of("key", "sp:set"));
+            assertEquals(2, rows.size());
+            long remaining = rows.stream().filter(r -> !popped.equals(r.get("member"))).count();
+            assertEquals(2, remaining);
+        }
+    }
+
+    @Test
+    void testSmove() throws Exception {
+        try (Jedis jedis = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
+            jedis.sadd("src:set", "apple", "banana");
+            jedis.sadd("dst:set", "cherry");
+
+            jedis.smove("src:set", "dst:set", "apple");
+
+            // apple removed from src store
+            assertEquals(0, store.select(Jedis.SETS_TABLE, Map.of("key", "src:set")).stream()
+                    .filter(r -> "apple".equals(r.get("member"))).count());
+            // apple added to dst store
+            assertEquals(1, store.select(Jedis.SETS_TABLE, Map.of("key", "dst:set")).stream()
+                    .filter(r -> "apple".equals(r.get("member"))).count());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Sorted set extended ops
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testZincrby() throws Exception {
+        try (Jedis jedis = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
+            jedis.zadd("zi:zset", 10.0, "alice");
+
+            double newScore = jedis.zincrby("zi:zset", 5.0, "alice");
+
+            assertEquals(15.0, newScore, 0.001);
+
+            List<Map<String, Object>> rows = store.select(Jedis.ZSETS_TABLE, Map.of("key", "zi:zset"));
+            double stored = ((Number) rows.get(0).get("score")).doubleValue();
+            assertEquals(15.0, stored, 0.001);
+        }
+    }
+
+    @Test
+    void testZpopmin() throws Exception {
+        try (Jedis jedis = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
+            jedis.zadd("zpm:zset", 1.0, "low");
+            jedis.zadd("zpm:zset", 5.0, "mid");
+            jedis.zadd("zpm:zset", 9.0, "high");
+
+            redis.clients.jedis.resps.Tuple t = jedis.zpopmin("zpm:zset");
+
+            assertEquals("low", t.getElement());
+
+            // 2 members remain in store
+            assertEquals(2, store.select(Jedis.ZSETS_TABLE, Map.of("key", "zpm:zset")).size());
+        }
+    }
+
+    @Test
+    void testZpopmax() throws Exception {
+        try (Jedis jedis = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
+            jedis.zadd("zpx:zset", 1.0, "low");
+            jedis.zadd("zpx:zset", 5.0, "mid");
+            jedis.zadd("zpx:zset", 9.0, "high");
+
+            redis.clients.jedis.resps.Tuple t = jedis.zpopmax("zpx:zset");
+
+            assertEquals("high", t.getElement());
+
+            assertEquals(2, store.select(Jedis.ZSETS_TABLE, Map.of("key", "zpx:zset")).size());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Store expiry purge
+    // -------------------------------------------------------------------------
+
+    /**
+     * Verifies that {@link Jedis#purgeExpired()} removes rows whose TTL has
+     * elapsed from every backing store table while leaving non-expired rows
+     * untouched.
+     *
+     * <p>Strategy: write short-lived entries (TTL 1 ms, already expired by the
+     * time we set {@code expires_at} to a past timestamp) alongside permanent
+     * entries across all five data types, call {@code purgeExpired()} explicitly,
+     * then assert only the permanent rows survive in the store.
+     */
+    @Test
+    void testPurgeExpiredRemovesExpiredRowsFromStore() throws Exception {
+        try (Jedis jedis = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
+
+            // ── Strings ──────────────────────────────────────────────────────
+            jedis.set("purge:str:keep",    "permanent");
+            jedis.set("purge:str:expired", "gone");
+            // Backdating expires_at to 1 ms past epoch means this row is already expired
+            backdateExpiry(Jedis.STRINGS_TABLE, "key", "purge:str:expired");
+
+            // ── Hashes ───────────────────────────────────────────────────────
+            jedis.hset("purge:hash:keep",    "f1", "v1");
+            jedis.hset("purge:hash:expired", "f2", "v2");
+            backdateExpiry(Jedis.HASHES_TABLE, "hash_key", "purge:hash:expired");
+
+            // ── Lists ────────────────────────────────────────────────────────
+            jedis.rpush("purge:list:keep",    "item1");
+            jedis.rpush("purge:list:expired", "item2");
+            backdateExpiry(Jedis.LISTS_TABLE, "key", "purge:list:expired");
+
+            // ── Sets ─────────────────────────────────────────────────────────
+            jedis.sadd("purge:set:keep",    "m1");
+            jedis.sadd("purge:set:expired", "m2");
+            backdateExpiry(Jedis.SETS_TABLE, "key", "purge:set:expired");
+
+            // ── Sorted sets ───────────────────────────────────────────────────
+            jedis.zadd("purge:zset:keep",    1.0, "mem1");
+            jedis.zadd("purge:zset:expired", 2.0, "mem2");
+            backdateExpiry(Jedis.ZSETS_TABLE, "key", "purge:zset:expired");
+
+            // ── Confirm expired rows exist before purge ───────────────────────
+            assertFalse(store.select(Jedis.STRINGS_TABLE, Map.of("key",      "purge:str:expired")).isEmpty(),  "expired string row should exist before purge");
+            assertFalse(store.select(Jedis.HASHES_TABLE,  Map.of("hash_key", "purge:hash:expired")).isEmpty(), "expired hash row should exist before purge");
+            assertFalse(store.select(Jedis.LISTS_TABLE,   Map.of("key",      "purge:list:expired")).isEmpty(), "expired list row should exist before purge");
+            assertFalse(store.select(Jedis.SETS_TABLE,    Map.of("key",      "purge:set:expired")).isEmpty(),  "expired set row should exist before purge");
+            assertFalse(store.select(Jedis.ZSETS_TABLE,   Map.of("key",      "purge:zset:expired")).isEmpty(), "expired zset row should exist before purge");
+
+            // ── Purge ─────────────────────────────────────────────────────────
+            jedis.purgeExpired();
+
+            // ── Expired rows must be gone ─────────────────────────────────────
+            assertTrue(store.select(Jedis.STRINGS_TABLE, Map.of("key",      "purge:str:expired")).isEmpty(),  "expired string row should be removed by purge");
+            assertTrue(store.select(Jedis.HASHES_TABLE,  Map.of("hash_key", "purge:hash:expired")).isEmpty(), "expired hash row should be removed by purge");
+            assertTrue(store.select(Jedis.LISTS_TABLE,   Map.of("key",      "purge:list:expired")).isEmpty(), "expired list row should be removed by purge");
+            assertTrue(store.select(Jedis.SETS_TABLE,    Map.of("key",      "purge:set:expired")).isEmpty(),  "expired set row should be removed by purge");
+            assertTrue(store.select(Jedis.ZSETS_TABLE,   Map.of("key",      "purge:zset:expired")).isEmpty(), "expired zset row should be removed by purge");
+
+            // ── Non-expired rows must survive ─────────────────────────────────
+            assertFalse(store.select(Jedis.STRINGS_TABLE, Map.of("key",      "purge:str:keep")).isEmpty(),  "non-expired string row should survive purge");
+            assertFalse(store.select(Jedis.HASHES_TABLE,  Map.of("hash_key", "purge:hash:keep")).isEmpty(), "non-expired hash row should survive purge");
+            assertFalse(store.select(Jedis.LISTS_TABLE,   Map.of("key",      "purge:list:keep")).isEmpty(), "non-expired list row should survive purge");
+            assertFalse(store.select(Jedis.SETS_TABLE,    Map.of("key",      "purge:set:keep")).isEmpty(),  "non-expired set row should survive purge");
+            assertFalse(store.select(Jedis.ZSETS_TABLE,   Map.of("key",      "purge:zset:keep")).isEmpty(), "non-expired zset row should survive purge");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Backdates the {@code expires_at} column of all rows that match
+     * {@code keyCol = keyVal} in the given table to 1 ms (long in the past),
+     * so that {@link Jedis#purgeExpired()} treats them as expired.
+     */
+    private void backdateExpiry(String table, String keyCol, String keyVal) throws Exception {
+        Map<String, Object> set   = Map.of("expires_at", 1L);           // epoch + 1 ms = always expired
+        Map<String, Object> where = Map.of(keyCol, keyVal);
+        store.update(table, set, where);
+    }
+
+    private static void deleteRecursively(Path path) {
+        if (Files.notExists(path)) return;
+        if (Files.isDirectory(path)) {
+            try (var stream = Files.list(path)) {
+                for (Path child : stream.collect(Collectors.toList())) {
+                    deleteRecursively(child);
+                }
+            } catch (IOException ignored) {}
+        }
+        try {
+            Files.deleteIfExists(path);
+        } catch (IOException ignored) {
+            // On Windows the SyncLite background thread may briefly hold a
+            // file lock on trace/WAL files after closeAllDevices().  Skip any
+            // locked file — the next test run will clean it up.
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Introduces `io.synclite.logger.Jedis` — a drop-in subclass of `redis.clients.jedis.Jedis` that durably persists every write to a `SyncLiteStore` before forwarding it to Redis. On restart the cache is automatically re-populated from the store, making Redis data self-healing across crashes and evictions. A comprehensive 41-test suite using an embedded in-process Redis mock (`jedis-mock`) is included.

---

## 1. New Class: `Jedis`

### Motivation

Redis is an in-memory store — all data is gone the moment the server restarts, the process is evicted, or the host is replaced. Applications that use Redis for session data, leaderboards, shopping carts, rate-limiting buckets, and similar stateful concerns currently have no durable recovery path: after a restart they must either reconstruct the cache from a primary database (expensive, slow) or accept a cold-cache penalty.

`io.synclite.logger.Jedis` solves this by intercepting every write at the client level. Before the write reaches Redis, the wrapper commits it durably to a `SyncLiteStore` (a local embedded database file captured by SyncLite's replication log). When the application restarts the Jedis instance re-populates Redis from the store automatically — no external tooling, no snapshot restore, no warm-up script needed.

A secondary benefit is CDC: because every write goes through `SyncLiteStore`, downstream SyncLite consumers automatically receive a real-time change-data stream of all Redis mutations — enabling audit trails, analytics, or downstream replication of cache state without any extra instrumentation.

### Approach

`Jedis` extends `redis.clients.jedis.Jedis` directly, making it a transparent drop-in for any code that already depends on the upstream Jedis client.

**Write path — store-first:**
Every supported write override follows the same three-step contract:
1. Persist the mutation to the `SyncLiteStore` (INSERT / UPDATE / DELETE against one of five typed tables).
2. Forward the call to `super.method(…)` so Redis stays authoritative for reads.
3. Return the result from Redis unchanged.

**Read path — pass-through:**
No read methods are overridden. All `get`, `hget`, `lrange`, `smembers`, etc. fall straight through to Redis. Redis remains the live query engine; the store is the durable log.

**Warm-up on construction:**
The private constructor calls `warmUp()` immediately after `initStoreTables()`. For each of the five tables it reads all non-expired rows and issues the corresponding Redis write (`set`, `hset`, `rpush`, `sadd`, `zadd`), so the in-memory cache reflects the last-known durable state before the application begins serving traffic.

**Async expiry purge:**
A single-threaded daemon `ScheduledExecutorService` runs `purgeExpired()` at a configurable interval (default 60 s). It deletes rows where `expires_at > 0 AND expires_at < currentTimeMillis()` from all five tables. The scheduler is shut down via `close()`.

**Builder API:**
```java
// store-first (most common)
Jedis jedis = Jedis.builder(store)
                   .host("redis-host").port(6380)
                   .storePurgeInterval(30, TimeUnit.SECONDS)
                   .build();

// host/port-first
Jedis jedis = Jedis.builder("redis-host", 6380).store(store).build();
```

### Files Changed

| File | Status | Description |
|---|---|---|
| `src/main/java/io/synclite/logger/Jedis.java` | **New** | Full `Jedis` implementation (~650 lines) |
| `src/test/java/io/synclite/logger/JedisTest.java` | **New** | 41-test JUnit 5 suite using `jedis-mock` |
| `pom.xml` | **Modified** | Added `redis.clients:jedis:4.4.8` and `com.github.fppt:jedis-mock:1.1.2` (test scope) |

### Store Schema

Five tables are created (or reused if they already exist) inside the `SyncLiteStore`:

| Table | Columns | Notes |
|---|---|---|
| `jedis_strings` | `key TEXT PK, value TEXT, expires_at BIGINT` | One row per string/binary key |
| `jedis_hashes`  | `hash_key TEXT, field TEXT, value TEXT, expires_at BIGINT` — PK(`hash_key`, `field`) | Field-level granularity |
| `jedis_lists`   | `key TEXT, idx BIGINT, value TEXT, expires_at BIGINT` — PK(`key`, `idx`) | `idx` used for push/pop ordering |
| `jedis_sets`    | `key TEXT, member TEXT, expires_at BIGINT` — PK(`key`, `member`) | Membership only |
| `jedis_zsets`   | `key TEXT, score DOUBLE, member TEXT, expires_at BIGINT` — PK(`key`, `member`) | Score stored for replay |

`expires_at` stores millisecond epoch; `0` means no TTL.

### Supported Write Operations

All of the following are overridden to persist to the store before forwarding to Redis:

**String / key ops:**
`set`, `setex`, `psetex`, `set(SetParams)`, `setnx`, `mset`, `msetnx`, `getDel`, `getSet`, `del`, `unlink`, `rename`, `persist`, `expire`, `pexpire`, `expireAt`, `pexpireAt`

**Hash ops:**
`hset(key, field, value)`, `hset(key, Map)`, `hdel`

**List ops:**
`rpush`, `lpush`, `lpushx`, `rpushx`, `lset`, `lpop`, `rpop`, `lrem`, `ltrim`

**Set ops:**
`sadd`, `srem`, `spop(key)`, `spop(key, count)`, `smove`

**Sorted-set ops:**
`zadd(key, score, member)`, `zadd(key, Map)`, `zadd(key, score, member, ZAddParams)`, `zadd(key, Map, ZAddParams)`, `zrem`, `zincrby`, `zpopmin(key)`, `zpopmin(key, count)`, `zpopmax(key)`, `zpopmax(key, count)`

---

## 2. Test Suite: `JedisTest`

### Infrastructure

- **Embedded Redis** via `jedis-mock 1.1.2` (`com.github.fppt`): a pure-Java in-process fake Redis. No Docker, no binary install, no network port conflicts.
- `@BeforeAll` / `@AfterAll`: single `RedisServer` instance shared across all 41 tests.
- `@BeforeEach`: `jedis.flushAll()` + fresh SQLite store directory per test, ensuring full isolation.
- `deleteRecursively()`: non-throwing; silently skips Windows-locked `.trace` files.

### Key Test Scenarios

| Test | What it validates |
|---|---|
| `testRestartReloadsAllTypesFromStore` | Writes all 5 data types → closes store + `closeAllDevices()` → flushes Redis → opens same DB file → new `Jedis` instance → asserts all 5 types restored from store |
| `testPurgeExpiredRemovesExpiredRowsFromStore` | Writes keep + expired entries across all 5 tables → backdates `expires_at=1` via `store.update()` → calls `purgeExpired()` → verifies expired rows gone, keep rows intact |
| `testSetWithSetParams` | EX / PX TTL stored correctly via `params.getParam("ex"/"px")` public API |
| `testWarmUpRebuildsCacheFromStore` | Manual Redis `del` → new `Jedis` instance rebuilds strings + hashes from store |
| `testListWarmUp` / `testSetWarmUp` / `testZSetWarmUp` | Per-type warm-up correctness |

All 41 tests pass:

```
Tests run: 41, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

---

## 3. Current Limitations

These operations are **not** supported by this wrapper and throw `UnsupportedOperationException`. The reason for each is explained below.

### In-place atomic mutations

`incr`, `incrBy`, `incrByFloat`, `decr`, `decrBy`, `append`, `setrange`, `hsetnx`, `hincrBy`, `hincrByFloat`

**Why unsupported:** These mutations read the current Redis value, modify it atomically, and return the result — all inside a single Redis command. The store has no way to replicate this reliably: you would need to issue a `SELECT` then an `UPDATE` per operation, which is not atomic and would diverge under concurrency. The store value would become stale the first time two threads call `incr` on the same key simultaneously.

### Aggregation-store operations

`sunionstore`, `sinterstore`, `sdiffstore`, `zunionstore`, `zinterstore`, `zdiffStore`, `zrangestore`

**Why unsupported:** These commands take two or more source keys, compute a set/sorted-set operation, and write the result to a destination key — all server-side. To store this durably you would need to fetch the full contents of all source keys from Redis first, compute the union/intersection/diff locally, then persist the result. This is expensive and still not truly atomic. Use the corresponding read-only variants (`sunion`, `sinter`, etc.) and manage the destination key lifecycle yourself.

### Advanced data types

`geoadd` and related geo commands, `pfadd` / `pfmerge` (HyperLogLog), `setbit` / `bitop` / `bitfield` (Bitmap), `xadd` / `xdel` / `xtrim` / `xack` (Streams)

**Why unsupported:** These types have no natural SQL row representation. Geo coordinates require spatial encoding; HyperLogLog is a probabilistic sketch; Bitmaps are position-indexed bit arrays; Streams are append-only ordered logs. Faithfully persisting and replaying them would require type-specific serialisation not yet implemented.

### Miscellaneous unsupported ops

- `renamenx` — race condition between existence check and rename cannot be replicated atomically in the store. Use `rename()` instead.
- `copy(src, dst, ...)` — semantics equivalent to a read + write; not yet implemented.
- `move` — moves a key between Redis databases; not a concept in the store model.
- `restore` — restores a key from a serialized RDB dump; not relevant to the store model.
- `sort(key, SortingParams, dstKey)` — sort-with-store variant; use the read-only `sort(key, SortingParams)`.
- `linsert`, `lmove`, `blmove`, `blpop`, `brpop` — positional-insert and blocking list ops; complex semantics / blocking behaviour not yet implemented.

### `SetParams` NX / XX semantics in the store

When `set(key, value, SetParams)` is called with `NX` (only set if not exists) or `XX` (only set if exists), the NX/XX guard is enforced by Redis. However, the store always upserts unconditionally. This means the store may contain a row for a key that Redis rejected due to NX/XX. Treat the store as an eventually-consistent CDC log, not a mirror of Redis's exact key set when NX/XX is in use.

---

## 4. Recommendations

1. **One `Jedis` instance per thread.** Neither the upstream Jedis client nor this wrapper is thread-safe. Use a pool pattern (`JedisPool` wrapping this class is not yet implemented — manage one Jedis + one SyncLiteStore per thread manually).

2. **Tune `storePurgeInterval` to fit your key churn rate.** The default 60-second interval works for most workloads. For high-TTL-key-churn applications (i.e., millions of short-lived keys per minute) reduce it; for stable long-lived keys you can increase it to reduce store write pressure.

3. **Plan for warm-up time on large datasets.** `warmUp()` runs synchronously in the constructor and reads the entire store into Redis before `build()` returns. For stores with millions of keys this can take tens of seconds. Consider pre-expiring aggressively before shutdown, or partitioning large datasets across multiple store files and Jedis instances.

4. **Do not rely on the store for NX / XX mutual exclusion.** The store upserts regardless of SetParams flags. If you need the store to faithfully mirror NX/XX results, read the Redis response and conditionally delete the row you just inserted on a rejected-NX / rejected-XX response. A helper utility method for this may be added in a future release.

5. **For atomic-increment use cases, keep a separate Jedis instance.** If your application needs `incr` / `hincrBy` on certain keys, use a plain (non-SyncLite) `redis.clients.jedis.Jedis` for those keys and this wrapper for the rest. Do not mix increment-heavy keys and durable-cache keys in the same `Jedis` instance.

6. **Monitor store growth.** Each write appends to the SyncLite replication log as well as updating the store table. Long-running applications that write many unique keys will accumulate log segments. Configure `SyncLiteOptions` log-cleanup settings appropriately.

