### PR TITLE
Block user SQL from dropping protected internal table synclite_txn

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,60 +1,69 @@
 # PR Description
 
 ## Summary
-This PR fixes INSERT validation behavior when a database connection is available but the SQL logger instance is not yet resolved.
 
-The validation now:
-- continues semantic INSERT validation when `conn` is present,
-- uses logger-backed table column count lookup when logger is available,
-- falls back to direct `PRAGMA table_info(...)` column count lookup when logger is null.
+Block user SQL from dropping `synclite_txn`, the internal transaction-tracking table present in every SyncLite device database (SQLite, DuckDB, Derby, H2, HyperSQL). Dropping this table via user SQL corrupts the device and makes it unrecoverable.
 
-This preserves the current strict requirement that INSERT statements must provide values for all table columns in DBLogger/Appender/Streaming validation paths.
+---
 
-## Problem
-In the previous implementation, validation returned early when either `conn` or `logger` was null.
+## Background
 
-That meant table-column count checks were skipped in cases where:
-- `conn` was available,
-- `logger` was temporarily null.
+Every SyncLite device database file maintains a table named `synclite_txn` that SyncLite uses internally to track transaction state. This table must not be dropped by user-issued SQL. Previously there was no guard preventing this.
 
-As a result, statements could bypass strict column count enforcement in that window.
-
-## Root Cause
-Early return condition was too broad:
-- `if (conn == null || logger == null) return;`
-
-The logger is only required for cached metadata lookup, not for performing the validation itself when connection metadata is accessible.
+---
 
 ## What Changed
-### Code changes
-- Updated early-return condition to require only null connection for short-circuit:
-  - from `if (conn == null || logger == null) return;`
-  - to `if (conn == null) return;`
-- Added fallback path in column count lookup:
-  - use `logger.getOrLoadTableColumnCount(...)` when logger is present,
-  - otherwise execute `PRAGMA table_info(<TABLE>)` on the active connection and count columns.
+
+Added `SyncLiteUtils.validateProtectedInternalTableDDL(String sql, String tableName)` which throws `SQLException` if a `DROP TABLE` targets `synclite_txn` (case-insensitive match).
+
+The guard is called from all user-facing SQL execution paths:
+
+| Class | Device scope |
+|---|---|
+| `DBLoggerStatement` | DBLogger, Streaming (Statement) |
+| `DBLoggerPreparedStatement` | DBLogger, Streaming (PreparedStatement) |
+| `SyncLiteStoreStatement` | Store, Appender (Statement) |
+| `SyncLiteStorePreparedStatement` | Store, Appender (PreparedStatement) |
+| `SyncLiteStatement` | SQLite, DuckDB, Derby, H2, HyperSQL transactional (Statement) |
+| `SyncLitePreparedStatement` | SQLite, DuckDB, Derby, H2, HyperSQL transactional (PreparedStatement) |
+
+For prepared statements the guard fires at `Connection.prepareStatement()` construction time, before any `execute()` call. Internal SyncLite cleanup paths that use raw JDBC (e.g. `SQLLogger.resetDeviceCheckpoint()`) bypass all wrappers and are not affected.
+
+---
 
 ## Files Changed
+
+**Main:**
 - `logger/src/main/java/io/synclite/logger/SyncLiteUtils.java`
-- `PR_DESCRIPTION.md`
+- `logger/src/main/java/io/synclite/logger/DBLoggerStatement.java`
+- `logger/src/main/java/io/synclite/logger/DBLoggerPreparedStatement.java`
+- `logger/src/main/java/io/synclite/logger/SyncLiteStoreStatement.java`
+- `logger/src/main/java/io/synclite/logger/SyncLiteStorePreparedStatement.java`
+- `logger/src/main/java/io/synclite/logger/SyncLiteStatement.java`
+- `logger/src/main/java/io/synclite/logger/SyncLitePreparedStatement.java`
 
-## Behavior Impact
-- INSERT validation remains strict and consistent even when logger lookup is unavailable.
-- No behavior change when logger is available.
+**Tests:**
+- `logger/src/test/java/io/synclite/logger/StreamingTest.java`
+- `logger/src/test/java/io/synclite/logger/SQLiteStoreTest.java`
 
-## Risk Assessment
-Low to medium:
-- Touches validation path only.
-- Fallback query is read-only metadata query (`PRAGMA table_info`).
-- Potential edge case: quoted/special table names continue to rely on existing parser/extractor behavior.
+---
 
 ## Testing
-Manual/observed:
-- Verified no compilation errors in modified file via IDE diagnostics.
 
-Not run in this change set:
-- Full Maven test suite.
+- `StreamingTest.testBasicTableOperations` — asserts `DROP TABLE synclite_txn` throws via both `Statement.execute()` and `Connection.prepareStatement()`, and confirms the table remains queryable afterwards.
+- `SQLiteStoreTest.testBasicTableOperations` — same assertions for the Store device path.
+- All 4 targeted test cases pass.
+
+---
+
+## Risk Assessment
+
+Low. The change only adds a reject path for one specific DDL pattern (`DROP TABLE synclite_txn`). All other DDL on user tables is unaffected. Internal SyncLite reset/cleanup code is not routed through the guarded paths.
+
+---
 
 ## Suggested Reviewer Checks
-- Validate strict INSERT enforcement with and without logger availability.
-- Verify behavior on table names across casing/schema qualifiers.
+
+- Confirm `DROP TABLE synclite_txn` is blocked for all device types (SQLite, DuckDB, Derby, H2, HyperSQL).
+- Confirm `CREATE TABLE`, `ALTER TABLE`, and `DROP TABLE` on user tables are unaffected.
+- Confirm internal device reset/cleanup is not broken.

--- a/logger/src/main/java/io/synclite/logger/DBLoggerPreparedStatement.java
+++ b/logger/src/main/java/io/synclite/logger/DBLoggerPreparedStatement.java
@@ -46,6 +46,7 @@ public class DBLoggerPreparedStatement extends JDBC4PreparedStatement {
 				) {
 			this.isDDL = true;
 			this.tableNameInDDL = SyncLiteUtils.getTableNameFromDDL(stippedSql);
+			SyncLiteUtils.validateProtectedInternalTableDDL(stippedSql, this.tableNameInDDL);
 		} else if (tokens[0].equalsIgnoreCase("SELECT")) {
 			//Allowed SQL
 		} else {

--- a/logger/src/main/java/io/synclite/logger/DBLoggerStatement.java
+++ b/logger/src/main/java/io/synclite/logger/DBLoggerStatement.java
@@ -60,6 +60,7 @@ public class DBLoggerStatement extends JDBC4Statement {
 	}
 
 	public final boolean executeUnlogged(String sql) throws SQLException {
+		SyncLiteUtils.validateProtectedInternalTableDDL(sql, SyncLiteUtils.getTableNameFromDDL(sql));
 		boolean result = super.execute(sql);
 		if (getConn().getUserAutoCommit() == true) {
 			getConn().superCommit();
@@ -193,6 +194,7 @@ public class DBLoggerStatement extends JDBC4Statement {
 	}
 
 	private final boolean executeDDL(String sql) throws SQLException {
+		SyncLiteUtils.validateProtectedInternalTableDDL(sql, SyncLiteUtils.getTableNameFromDDL(sql));
 		boolean result = super.execute(sql);
 		String tableName = SyncLiteUtils.getTableNameFromDDL(sql);
 		if (tableName != null && sqlLogger != null) {

--- a/logger/src/main/java/io/synclite/logger/SyncLitePreparedStatement.java
+++ b/logger/src/main/java/io/synclite/logger/SyncLitePreparedStatement.java
@@ -32,6 +32,7 @@ public class SyncLitePreparedStatement extends JDBC4PreparedStatement {
         }
         this.sqlLogger = AsyncTxnLogger.findInstance(getConn().getPath());
         this.tableNameInDDL = SyncLiteUtils.getTableNameFromDDL(sql);
+        SyncLiteUtils.validateProtectedInternalTableDDL(sql, this.tableNameInDDL);
     }
 
     protected SyncLiteConnection getConn() {

--- a/logger/src/main/java/io/synclite/logger/SyncLiteStatement.java
+++ b/logger/src/main/java/io/synclite/logger/SyncLiteStatement.java
@@ -39,6 +39,7 @@ public class SyncLiteStatement extends JDBC4Statement {
     }
 
     public final boolean executeUnlogged(String sql) throws SQLException {    	
+        SyncLiteUtils.validateProtectedInternalTableDDL(sql, SyncLiteUtils.getTableNameFromDDL(sql));
         boolean result = stmtExecute(sql, SyncLiteUtils.getTableNameFromDDL(sql), new StringBuilder());
 		if (getConn().getUserAutoCommit() == true) {
 			getConn().connCommit();
@@ -60,8 +61,10 @@ public class SyncLiteStatement extends JDBC4Statement {
     private final boolean executeInternal(String sql) throws SQLException {
     	boolean result = false;
 		StringBuilder sqlToLog = new StringBuilder();
+        String tableNameInDDL = SyncLiteUtils.getTableNameFromDDL(sql);
+        SyncLiteUtils.validateProtectedInternalTableDDL(sql, tableNameInDDL);
     	try {
-    		result = stmtExecute(sql, SyncLiteUtils.getTableNameFromDDL(sql), sqlToLog);
+            result = stmtExecute(sql, tableNameInDDL, sqlToLog);
     	} catch (SQLException e) {
     		if (e.getMessage().contains("syntax error") || e.getMessage().contains("Parse error")) {
     			try {
@@ -86,8 +89,10 @@ public class SyncLiteStatement extends JDBC4Statement {
     private final int executeUpdateInternal(String sql) throws SQLException {
     	int result = 0;
 		StringBuilder sqlToLog = new StringBuilder();
+        String tableNameInDDL = SyncLiteUtils.getTableNameFromDDL(sql);
+        SyncLiteUtils.validateProtectedInternalTableDDL(sql, tableNameInDDL);
     	try {
-    		result = stmtExecuteUpdate(sql, SyncLiteUtils.getTableNameFromDDL(sql), sqlToLog);
+            result = stmtExecuteUpdate(sql, tableNameInDDL, sqlToLog);
     	} catch (SQLException e) {
     		if (e.getMessage().contains("syntax error") || e.getMessage().contains("Parse error")) {
     			try {
@@ -125,6 +130,7 @@ public class SyncLiteStatement extends JDBC4Statement {
     	ResultSet rs = null;
         try {
         	String tableNameInDDL = SyncLiteUtils.getTableNameFromDDL(sql);
+			SyncLiteUtils.validateProtectedInternalTableDDL(sql, tableNameInDDL);
         	rs = stmtExecuteQuery(sql, tableNameInDDL);
             if (tableNameInDDL != null) {
                 log(sql);
@@ -165,6 +171,7 @@ public class SyncLiteStatement extends JDBC4Statement {
     }
 
     public final int executeUnloggedUpdate(String sql) throws SQLException {    	
+        SyncLiteUtils.validateProtectedInternalTableDDL(sql, SyncLiteUtils.getTableNameFromDDL(sql));
         return stmtExecuteUpdate(sql, SyncLiteUtils.getTableNameFromDDL(sql), new StringBuilder());
     }
 

--- a/logger/src/main/java/io/synclite/logger/SyncLiteStorePreparedStatement.java
+++ b/logger/src/main/java/io/synclite/logger/SyncLiteStorePreparedStatement.java
@@ -51,6 +51,7 @@ public class SyncLiteStorePreparedStatement extends JDBC4PreparedStatement {
         }
         this.sqlLogger = logger;
         this.tableNameInDDL = SyncLiteUtils.getTableNameFromDDL(sql);
+        SyncLiteUtils.validateProtectedInternalTableDDL(strippedSql, this.tableNameInDDL);
     }
 
     // Package-private: for use by internal API layers (e.g. SyncLiteStore) that generate SQL

--- a/logger/src/main/java/io/synclite/logger/SyncLiteStoreStatement.java
+++ b/logger/src/main/java/io/synclite/logger/SyncLiteStoreStatement.java
@@ -41,6 +41,7 @@ public class SyncLiteStoreStatement extends JDBC4Statement {
     }
 
     public final boolean executeUnlogged(String sql) throws SQLException {
+        SyncLiteUtils.validateProtectedInternalTableDDL(sql, SyncLiteUtils.getTableNameFromDDL(sql));
         boolean result = stmtExecute(sql, SyncLiteUtils.getTableNameFromDDL(sql), new StringBuilder());
         if (getConn().getUserAutoCommit() == true) {
             getConn().superCommit();
@@ -124,6 +125,7 @@ public class SyncLiteStoreStatement extends JDBC4Statement {
     private final boolean executeDDL(String sql) throws SQLException {
         StringBuilder sqlToLog = new StringBuilder();
         String tableNameInDDL = SyncLiteUtils.getTableNameFromDDL(sql);
+        SyncLiteUtils.validateProtectedInternalTableDDL(sql, tableNameInDDL);
         boolean result = stmtExecute(sql, tableNameInDDL, sqlToLog);
         if (tableNameInDDL != null && sqlLogger != null) {
             sqlLogger.evictTableFromCache(tableNameInDDL);

--- a/logger/src/main/java/io/synclite/logger/SyncLiteUtils.java
+++ b/logger/src/main/java/io/synclite/logger/SyncLiteUtils.java
@@ -68,6 +68,7 @@ public class SyncLiteUtils {
 	private static final Pattern DDL_ALTER_COLUMN_PATTERN  = Pattern.compile("ALTER\\s+(?:COLUMN)?", Pattern.CASE_INSENSITIVE);
 	private static final Pattern DDL_RENAME_TO_PATTERN     = Pattern.compile("RENAME\\s+TO", Pattern.CASE_INSENSITIVE);
 	private static final Pattern DDL_RENAME_COLUMN_PATTERN = Pattern.compile("RENAME\\s+(?:COLUMN)?", Pattern.CASE_INSENSITIVE);
+	private static final String PROTECTED_TXN_TABLE_NAME = "SYNCLITE_TXN";
 
 	static final List<String> splitSqls(String sql) {
 		List<String> sqls = new ArrayList<String>();
@@ -597,6 +598,17 @@ public class SyncLiteUtils {
             }
         }
 		return tableName;
+	}
+
+	final static void validateProtectedInternalTableDDL(String sql, String tableName) throws SQLException {
+		if (tableName == null) {
+			return;
+		}
+
+		String strippedSql = sql.stripLeading();
+		if (strippedSql.regionMatches(true, 0, "DROP", 0, 4) && PROTECTED_TXN_TABLE_NAME.equalsIgnoreCase(tableName)) {
+			throw new SQLException("Protected internal table 'synclite_txn' cannot be dropped by user SQL.");
+		}
 	}
 
 

--- a/logger/src/test/java/io/synclite/logger/SQLiteStoreTest.java
+++ b/logger/src/test/java/io/synclite/logger/SQLiteStoreTest.java
@@ -99,6 +99,23 @@ class SQLiteStoreTest {
 
         // First transaction: create table and insert data
         try (Connection conn = DriverManager.getConnection(url)) {
+            SQLException protectedStmtEx;
+            try (Statement stmt = conn.createStatement()) {
+                protectedStmtEx = assertThrows(SQLException.class, () -> stmt.execute("DROP TABLE synclite_txn"));
+            }
+            assertTrue(protectedStmtEx.getMessage().contains("Protected internal table 'synclite_txn'"),
+                    "Statement drop should be blocked with protected-table message");
+
+                SQLException protectedPstmtEx = assertThrows(SQLException.class,
+                    () -> conn.prepareStatement("DROP TABLE synclite_txn"));
+                assertTrue(protectedPstmtEx.getMessage().contains("Protected internal table 'synclite_txn'"),
+                    "PreparedStatement drop should be blocked with protected-table message");
+
+            try (Statement stmt = conn.createStatement();
+                 ResultSet rs = stmt.executeQuery("SELECT commit_id FROM synclite_txn")) {
+                assertTrue(rs.next(), "synclite_txn must still exist after blocked drop attempts");
+            }
+
             try (Statement stmt = conn.createStatement()) {
                 stmt.execute("CREATE TABLE sqlitestore_table (id INTEGER PRIMARY KEY, name TEXT, value INTEGER)");
             }

--- a/logger/src/test/java/io/synclite/logger/StreamingTest.java
+++ b/logger/src/test/java/io/synclite/logger/StreamingTest.java
@@ -105,6 +105,23 @@ class StreamingTest {
 
         // First transaction: create table and insert data
         try (Connection conn = DriverManager.getConnection(url)) {
+            SQLException protectedStmtEx;
+            try (Statement stmt = conn.createStatement()) {
+                protectedStmtEx = assertThrows(SQLException.class, () -> stmt.execute("DROP TABLE synclite_txn"));
+            }
+            assertTrue(protectedStmtEx.getMessage().contains("Protected internal table 'synclite_txn'"),
+                    "Statement drop should be blocked with protected-table message");
+
+                SQLException protectedPstmtEx = assertThrows(SQLException.class,
+                    () -> conn.prepareStatement("DROP TABLE synclite_txn"));
+                assertTrue(protectedPstmtEx.getMessage().contains("Protected internal table 'synclite_txn'"),
+                    "PreparedStatement drop should be blocked with protected-table message");
+
+            try (Statement stmt = conn.createStatement();
+                 ResultSet rs = stmt.executeQuery("SELECT commit_id FROM synclite_txn")) {
+                assertTrue(rs.next(), "synclite_txn must still exist after blocked drop attempts");
+            }
+
             // Create table
             try (Statement stmt = conn.createStatement()) {
                 stmt.execute("CREATE TABLE streaming_table (id INTEGER PRIMARY KEY, name TEXT, value INTEGER)");


### PR DESCRIPTION
- Add validateProtectedInternalTableDDL() in SyncLiteUtils that throws SQLException if DROP TABLE targets synclite_txn (case-insensitive)
- Wire guard through all user-facing statement paths:
  * DBLoggerStatement / DBLoggerPreparedStatement (DBLogger, Streaming)
  * SyncLiteStoreStatement / SyncLiteStorePreparedStatement (Store, Appender)
  * SyncLiteStatement / SyncLitePreparedStatement (transactional: SQLite, DuckDB, Derby, H2, HyperSQL)
- For PreparedStatement, guard fires at prepareStatement() construction time
- Internal cleanup via raw JDBC (SQLLogger.resetDeviceCheckpoint) unaffected
- Add regression tests in StreamingTest and SQLiteStoreTest (4/4 passing)

Fixes: Prevent corruption of device by user-issued DROP TABLE synclite_txn