### PR TITLE
Add canonical Java/Python samples and expand Jedis API…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 Refer README of parent project for details : https://github.com/syncliteio/SyncLite
+
+Local sample apps are available under `logger/samples`.

--- a/logger/samples/README.md
+++ b/logger/samples/README.md
@@ -1,0 +1,28 @@
+# SyncLite Logger Samples
+
+This folder contains the canonical sample set requested for this repository.
+
+## Java
+
+- SyncliteDeviceApp.java
+- SyncLiteAppenderDeviceApp.java
+- SyncLiteStoreDeviceApp.java
+- SyncLiteStreamingApp.java
+- SyncLiteStoreAPIApp.java
+- SyncLiteStreamAPIApp.java
+- SyncLiteKafkaProduceApp.java
+- SyncLiteJedisAPIApp.java
+
+## Python
+
+- JayDeBeApi/ (SQL-style bridge samples)
+- JPype/ (direct Java API bridge samples)
+
+JPype folder includes API-style samples as well:
+
+- SyncLiteStoreAPIApp.py
+- SyncLiteStreamAPIApp.py
+- SyncLiteKafkaProduceAPIApp.py
+- SyncLiteJedisAPIApp.py
+
+See language-specific README files for quick run instructions.

--- a/logger/samples/java/README.md
+++ b/logger/samples/java/README.md
@@ -1,0 +1,13 @@
+# Java Samples
+
+Compile samples against the built logger jar:
+
+javac -cp ..\\..\\target\\synclite-logger-oss.jar *.java
+
+Run any sample (example):
+
+java -cp ..\\..\\target\\synclite-logger-oss.jar;. SyncliteDeviceApp
+
+Notes:
+- Samples default to SQLite and include inline comments for replacing SQL-device/appender device types.
+- Keep synclite_logger.conf in the current working directory.

--- a/logger/samples/java/SyncLiteAppenderDeviceApp.java
+++ b/logger/samples/java/SyncLiteAppenderDeviceApp.java
@@ -1,0 +1,63 @@
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import io.synclite.logger.SQLiteAppender;
+
+/**
+ * Appender device sample.
+ *
+ * Appender devices are meant for write-heavy ingest paths where the workload is
+ * dominated by appends. They keep the calling pattern simple and emphasize
+ * durable INSERT-style logging rather than broad relational mutation.
+ *
+ * Compared to a SQL device, this is intentionally narrower. If the workload
+ * needs arbitrary SQL semantics and statement replay on a replica, use a SQL
+ * device instead.
+ */
+public class SyncLiteAppenderDeviceApp {
+
+    public static void main(String[] args) throws ClassNotFoundException, SQLException {
+        appStartup();
+        SyncLiteAppenderDeviceApp app = new SyncLiteAppenderDeviceApp();
+        app.runBusinessLogic();
+    }
+
+    public static void appStartup() throws SQLException, ClassNotFoundException {
+        // Appender default: SQLiteAppender.
+        // Replace for other appender engines:
+        // 1) Driver class: io.synclite.logger.SQLiteAppender -> DerbyAppender, DuckDBAppender, H2Appender, HyperSQLAppender
+        // 2) Initialize call: SQLiteAppender.initialize(...) -> <Engine>Appender.initialize(...)
+        // 3) JDBC URL prefix in runBusinessLogic():
+        //    jdbc:synclite_sqlite_appender: -> jdbc:synclite_derby_appender:, jdbc:synclite_duckdb_appender:, jdbc:synclite_h2_appender:, jdbc:synclite_hsqldb_appender:
+        Class.forName("io.synclite.logger.SQLiteAppender");
+        Path dbPath = Path.of("sample_appender_sqlite.db");
+        SQLiteAppender.initialize(dbPath, Path.of("synclite_logger.conf"));
+    }
+
+    public void runBusinessLogic() throws SQLException {
+        try (Connection conn = DriverManager.getConnection("jdbc:synclite_sqlite_appender:sample_appender_sqlite.db")) {
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute("CREATE TABLE IF NOT EXISTS feedback(rating INT, comment TEXT)");
+            }
+
+            // Appender devices support DDL, INSERT, and SELECT.
+            try (PreparedStatement pstmt = conn.prepareStatement("INSERT INTO feedback VALUES(?, ?)")) {
+                pstmt.setInt(1, 4);
+                pstmt.setString(2, "Excellent Product");
+                pstmt.addBatch();
+
+                pstmt.setInt(1, 5);
+                pstmt.setString(2, "Outstanding Product");
+                pstmt.addBatch();
+
+                pstmt.executeBatch();
+            }
+        }
+
+        SQLiteAppender.closeDevice(Path.of("sample_appender_sqlite.db"));
+    }
+}

--- a/logger/samples/java/SyncLiteAppenderDeviceApp.java
+++ b/logger/samples/java/SyncLiteAppenderDeviceApp.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2024 mahendra.chavan@synclite.io, all rights reserved.
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.  See the License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
 import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.DriverManager;

--- a/logger/samples/java/SyncLiteJedisAPIApp.java
+++ b/logger/samples/java/SyncLiteJedisAPIApp.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2024 mahendra.chavan@synclite.io, all rights reserved.
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.  See the License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
 import java.nio.file.Path;
 import java.util.Map;
 

--- a/logger/samples/java/SyncLiteJedisAPIApp.java
+++ b/logger/samples/java/SyncLiteJedisAPIApp.java
@@ -1,0 +1,86 @@
+import java.nio.file.Path;
+import java.util.Map;
+
+import io.synclite.logger.Jedis;
+
+/**
+ * Jedis API sample.
+ *
+ * This sample shows Redis-style key/value usage backed by a SyncLite store
+ * device. It is useful when the application already speaks in Jedis terms and
+ * wants SyncLite-managed persistence under that API.
+ *
+ * The sample uses the managed builder mode added to Jedis, so the underlying
+ * store initialize, open, and close lifecycle is handled by Jedis rather than by
+ * the application.
+ */
+public class SyncLiteJedisAPIApp {
+
+    public static void main(String[] args) throws Exception {
+        Path dbPath = Path.of("sample_jedis_store.db");
+
+        // Managed mode: Jedis handles SQLiteStore initialize/open/close internally.
+        try (Jedis jedis = Jedis.builder(dbPath, Path.of("synclite_logger.conf"), "jedis-sample")
+                .host("localhost")
+                .port(6379)
+                .build()) {
+            // Clear keys used by this sample so repeated runs stay deterministic.
+            jedis.del(
+                "sample:user:1:name",
+                "sample:user:2:name",
+                "sample:user:3:name",
+                "sample:session:42",
+                "sample:queue",
+                "sample:tags",
+                "sample:leaderboard",
+                "sample:tmp"
+            );
+
+            // 1) Strings
+            jedis.set("sample:user:1:name", "Alice");
+            jedis.mset("sample:user:2:name", "Bob", "sample:user:3:name", "Carol");
+            System.out.println("GET sample:user:1:name = " + jedis.get("sample:user:1:name"));
+            System.out.println("MGET users = " + jedis.mget("sample:user:2:name", "sample:user:3:name"));
+
+            // 2) Hashes
+            jedis.hset("sample:session:42", Map.of(
+                "token", "abc123",
+                "status", "active",
+                "region", "us-east"
+            ));
+            System.out.println("HGET token = " + jedis.hget("sample:session:42", "token"));
+            System.out.println("HGETALL session = " + jedis.hgetAll("sample:session:42"));
+            jedis.hdel("sample:session:42", "region");
+
+            // 3) Lists
+            jedis.rpush("sample:queue", "job-1", "job-2");
+            jedis.lpush("sample:queue", "job-0");
+            System.out.println("LRANGE queue = " + jedis.lrange("sample:queue", 0, -1));
+            System.out.println("LPOP queue = " + jedis.lpop("sample:queue"));
+            System.out.println("RPOP queue = " + jedis.rpop("sample:queue"));
+
+            // 4) Sets
+            jedis.sadd("sample:tags", "etl", "cdc", "ops");
+            jedis.srem("sample:tags", "ops");
+            System.out.println("SMEMBERS tags = " + jedis.smembers("sample:tags"));
+
+            // 5) Sorted sets
+            jedis.zadd("sample:leaderboard", Map.of(
+                "alice", 9.5,
+                "bob", 8.0,
+                "carol", 9.8
+            ));
+            jedis.zincrby("sample:leaderboard", 0.3, "bob");
+            System.out.println("ZRANGE leaderboard = " + jedis.zrange("sample:leaderboard", 0, -1));
+            System.out.println("ZSCORE bob = " + jedis.zscore("sample:leaderboard", "bob"));
+
+            // 6) Key lifecycle
+            jedis.set("sample:tmp", "ephemeral");
+            jedis.expire("sample:tmp", 60);
+            System.out.println("TTL sample:tmp = " + jedis.ttl("sample:tmp"));
+            jedis.rename("sample:tmp", "sample:tmp:renamed");
+            jedis.persist("sample:tmp:renamed");
+            jedis.del("sample:tmp:renamed");
+        }
+    }
+}

--- a/logger/samples/java/SyncLiteKafkaProduceApp.java
+++ b/logger/samples/java/SyncLiteKafkaProduceApp.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2024 mahendra.chavan@synclite.io, all rights reserved.
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.  See the License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
 import java.nio.file.Path;
 import java.util.Properties;
 

--- a/logger/samples/java/SyncLiteKafkaProduceApp.java
+++ b/logger/samples/java/SyncLiteKafkaProduceApp.java
@@ -1,0 +1,33 @@
+import java.nio.file.Path;
+import java.util.Properties;
+
+import org.apache.kafka.clients.producer.ProducerRecord;
+
+import io.synclite.logger.KafkaProducer;
+
+/**
+ * KafkaProducer API sample.
+ *
+ * This sample shows producer-style publishing through the SyncLite KafkaProducer
+ * API. The application deals with records and topics directly instead of
+ * modeling messages as rows through a SQL surface.
+ *
+ * That makes it the API-oriented counterpart to the SQL-based streaming samples.
+ * Use this path when the application is already structured around Kafka producer
+ * semantics and you want SyncLite persistence behind that API.
+ */
+public class SyncLiteKafkaProduceApp {
+
+    public static void main(String[] args) throws Exception {
+        Properties props = new Properties();
+        props.put("bootstrap.servers", "localhost:9092");
+        props.put("device-path", Path.of("sample_kafka_device.db").toAbsolutePath().toString());
+        props.put("device-type", "STREAMING");
+
+        try (KafkaProducer producer = new KafkaProducer(props)) {
+            producer.send(new ProducerRecord<>("orders", "order-1", "{\"status\":\"created\"}"));
+            producer.send(new ProducerRecord<>("orders", "order-2", "{\"status\":\"confirmed\"}"));
+            producer.flush();
+        }
+    }
+}

--- a/logger/samples/java/SyncLiteStoreAPIApp.java
+++ b/logger/samples/java/SyncLiteStoreAPIApp.java
@@ -1,0 +1,90 @@
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.synclite.logger.SQLiteStore;
+import io.synclite.logger.SyncLiteStore;
+
+/**
+ * Store API sample.
+ *
+ * This sample uses the Store API rather than issuing raw SQL strings for every
+ * change. It targets the same store-device model as the JDBC store sample:
+ * mutable operations whose row data is explicit enough to be applied directly to
+ * downstream destinations.
+ *
+ * The contrast with a SQL device is semantic, not just syntactic. A SQL device
+ * can log arbitrary SQL and rely on replay plus CDC extraction later. The Store
+ * API is intentionally centered on direct CRUD-style changes, so patterns such
+ * as INSERT INTO ... SELECT ... are outside its core model. Column drop is still
+ * shown through JDBC DDL because Store API has no direct drop-column helper.
+ */
+public class SyncLiteStoreAPIApp {
+
+    public static void main(String[] args) throws ClassNotFoundException, SQLException {
+        Class.forName("io.synclite.logger.SQLiteStore");
+        Path dbPath = Path.of("sample_store_api.db");
+        SQLiteStore.initialize(dbPath, Path.of("synclite_logger.conf"));
+
+        try (SyncLiteStore store = SQLiteStore.open(dbPath)) {
+            // 1) CREATE TABLE via Store API
+            Map<String, String> columns = new LinkedHashMap<>();
+            columns.put("id", "INTEGER PRIMARY KEY");
+            columns.put("name", "TEXT");
+            columns.put("score", "INTEGER");
+            store.createTable("players", columns);
+
+            // Separate table for explicit DROP TABLE demonstration.
+            store.createTable("temp_players_archive", new LinkedHashMap<>(Map.of(
+                "id", "INTEGER",
+                "note", "TEXT"
+            )));
+
+            // 2) INSERT + batch INSERT
+            store.insert("players", Map.of("id", 1, "name", "Alice", "score", 100));
+            store.insertBatch("players", List.of(
+                Map.of("id", 2, "name", "Bob", "score", 200),
+                Map.of("id", 3, "name", "Carol", "score", 300)
+            ));
+
+            // 3) UPDATE
+            store.update("players", Map.of("score", 250), Map.of("name", "Bob"));
+
+            // 4) DELETE
+            store.delete("players", Map.of("id", 3));
+
+            // 5) ALTER TABLE ADD COLUMN (implicit via Store API auto-column-add)
+            store.update("players", Map.of("email", "alice@example.com"), Map.of("id", 1));
+
+            // 6) ALTER TABLE DROP COLUMN
+            // High-level Store API does not expose drop-column directly; execute DDL via JDBC.
+            try (Connection conn = DriverManager.getConnection("jdbc:synclite_sqlite_store:sample_store_api.db");
+                 Statement ddl = conn.createStatement()) {
+                ddl.execute("ALTER TABLE players DROP COLUMN email");
+            }
+
+            // 7) DROP TABLE (different table) via Store API
+            store.dropTable("temp_players_archive");
+
+            List<Map<String, Object>> rows = store.selectAll("players");
+            System.out.println("Store API rows count: " + rows.size());
+
+            // Optional query output for visibility
+            try (Connection conn = DriverManager.getConnection("jdbc:synclite_sqlite_store:sample_store_api.db");
+                 Statement stmt = conn.createStatement();
+                 ResultSet rs = stmt.executeQuery("SELECT id, name, score FROM players ORDER BY id")) {
+                while (rs.next()) {
+                    System.out.println("player=" + rs.getInt("id") + ", name=" + rs.getString("name") + ", score=" + rs.getInt("score"));
+                }
+            }
+        }
+
+        SQLiteStore.closeDevice(Path.of("sample_store_api.db"));
+    }
+}

--- a/logger/samples/java/SyncLiteStoreAPIApp.java
+++ b/logger/samples/java/SyncLiteStoreAPIApp.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2024 mahendra.chavan@synclite.io, all rights reserved.
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.  See the License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
 import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.DriverManager;

--- a/logger/samples/java/SyncLiteStoreDeviceApp.java
+++ b/logger/samples/java/SyncLiteStoreDeviceApp.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2024 mahendra.chavan@synclite.io, all rights reserved.
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.  See the License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
 import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.DriverManager;

--- a/logger/samples/java/SyncLiteStoreDeviceApp.java
+++ b/logger/samples/java/SyncLiteStoreDeviceApp.java
@@ -1,0 +1,94 @@
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import io.synclite.logger.SQLiteStore;
+
+/**
+ * Store device sample.
+ *
+ * A store device is for mutable operational data where the row changes are
+ * explicit in the operation itself, for example INSERT ... VALUES, UPDATE with
+ * concrete column values, and key-based DELETE flows. That lets SyncLite apply
+ * those changes directly to downstream destinations instead of replaying the SQL
+ * on a replica and harvesting CDC afterward.
+ *
+ * This is the core difference from a SQL device. A SQL device can accept
+ * arbitrary SQL because the consolidator can replay it and derive CDC from the
+ * replica. A store device is intentionally narrower, so statements such as
+ * INSERT INTO target SELECT ... FROM source are not the model to optimize for,
+ * because the inserted rows are not already present in the request.
+ */
+public class SyncLiteStoreDeviceApp {
+
+    public static void main(String[] args) throws ClassNotFoundException, SQLException {
+        Class.forName("io.synclite.logger.SQLiteStore");
+        Path dbPath = Path.of("sample_store_sqlite.db");
+        SQLiteStore.initialize(dbPath, Path.of("synclite_logger.conf"));
+
+        try (Connection conn = DriverManager.getConnection("jdbc:synclite_sqlite_store:sample_store_sqlite.db")) {
+            try (Statement stmt = conn.createStatement()) {
+                // 1) CREATE TABLE
+                stmt.execute("CREATE TABLE IF NOT EXISTS users(id INT PRIMARY KEY, name TEXT)");
+
+                // Extra table only to demonstrate DROP TABLE on a different table.
+                stmt.execute("CREATE TABLE IF NOT EXISTS temp_audit(id INT, note TEXT)");
+            }
+
+            // 2) INSERT
+            try (PreparedStatement insert = conn.prepareStatement("INSERT INTO users(id, name) VALUES(?, ?)");
+                 PreparedStatement update = conn.prepareStatement("UPDATE users SET name = ? WHERE id = ?");
+                 PreparedStatement delete = conn.prepareStatement("DELETE FROM users WHERE id = ?");
+                 Statement schema = conn.createStatement();
+                 Statement query = conn.createStatement()) {
+                insert.setInt(1, 1);
+                insert.setString(2, "Alice");
+                insert.executeUpdate();
+
+                insert.setInt(1, 2);
+                insert.setString(2, "Bob");
+                insert.executeUpdate();
+
+                // 3) UPDATE
+                update.setString(1, "Alice Cooper");
+                update.setInt(2, 1);
+                update.executeUpdate();
+
+                // 4) DELETE
+                delete.setInt(1, 2);
+                delete.executeUpdate();
+
+                // 5) ALTER TABLE ADD COLUMN
+                schema.execute("ALTER TABLE users ADD COLUMN email TEXT");
+
+                // Fill the newly added column
+                try (PreparedStatement fillEmail = conn.prepareStatement("UPDATE users SET email = ? WHERE id = ?")) {
+                    fillEmail.setString(1, "alice@example.com");
+                    fillEmail.setInt(2, 1);
+                    fillEmail.executeUpdate();
+                }
+
+                // 6) ALTER TABLE DROP COLUMN
+                schema.execute("ALTER TABLE users DROP COLUMN email");
+
+                // 7) DROP TABLE (different table)
+                schema.execute("DROP TABLE IF EXISTS temp_audit");
+
+                // Read final data to verify sample flow
+                try (ResultSet rs = query.executeQuery("SELECT id, name FROM users ORDER BY id")) {
+                    while (rs.next()) {
+                        int id = rs.getInt("id");
+                        String name = rs.getString("name");
+                        System.out.println("user=" + id + ", name=" + name);
+                    }
+                }
+            }
+        }
+
+        SQLiteStore.closeDevice(Path.of("sample_store_sqlite.db"));
+    }
+}

--- a/logger/samples/java/SyncLiteStreamAPIApp.java
+++ b/logger/samples/java/SyncLiteStreamAPIApp.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2024 mahendra.chavan@synclite.io, all rights reserved.
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.  See the License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
 import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.DriverManager;

--- a/logger/samples/java/SyncLiteStreamAPIApp.java
+++ b/logger/samples/java/SyncLiteStreamAPIApp.java
@@ -1,0 +1,91 @@
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.synclite.logger.Streaming;
+import io.synclite.logger.SyncLiteStream;
+
+/**
+ * Stream API sample.
+ *
+ * This sample uses the Stream API for append-oriented event ingestion. It is the
+ * API-level counterpart to the streaming-device JDBC sample and is meant for
+ * workloads where new records are emitted continuously.
+ *
+ * The distinction from Store API is that Stream API is not modeling mutable
+ * business rows. It models event flow. INSERT remains the core operation,
+ * selected DDL is available for schema evolution, and UPDATE or DELETE are
+ * intentionally unsupported.
+ */
+public class SyncLiteStreamAPIApp {
+
+    public static void main(String[] args) throws ClassNotFoundException, SQLException {
+        Class.forName("io.synclite.logger.Streaming");
+        Path dbPath = Path.of("sample_stream_api.db");
+        Streaming.initialize(dbPath, Path.of("synclite_logger.conf"));
+
+        try (SyncLiteStream stream = SyncLiteStream.open(dbPath)) {
+            // 1) CREATE TABLE via Stream API
+            stream.createTable("events", new LinkedHashMap<>(Map.of(
+                "ts", "BIGINT",
+                "event_type", "TEXT",
+                "user_id", "TEXT"
+            )));
+
+            // Separate table to demonstrate DROP TABLE on a different table.
+            stream.createTable("temp_events_archive", new LinkedHashMap<>(Map.of(
+                "id", "INT",
+                "note", "TEXT"
+            )));
+
+            // 2) INSERT + batch INSERT via Stream API
+            stream.insert("events", Map.of(
+                "ts", System.currentTimeMillis(),
+                "event_type", "SIGNUP",
+                "user_id", "user-10"
+            ));
+
+            stream.insertBatch("events", List.of(
+                Map.of("ts", System.currentTimeMillis(), "event_type", "VIEW", "user_id", "user-11"),
+                Map.of("ts", System.currentTimeMillis(), "event_type", "CLICK", "user_id", "user-12")
+            ));
+
+            // 3) ALTER TABLE ADD COLUMN (implicit via Stream API auto-column-add)
+            stream.insert("events", Map.of(
+                "ts", System.currentTimeMillis(),
+                "event_type", "PURCHASE",
+                "user_id", "user-13",
+                "source", "web"
+            ));
+
+            // 4) ALTER TABLE DROP COLUMN
+            // Stream API does not expose drop-column directly; execute DDL via JDBC.
+            try (Connection conn = DriverManager.getConnection("jdbc:synclite_streaming:sample_stream_api.db");
+                 Statement ddl = conn.createStatement()) {
+                ddl.execute("ALTER TABLE events DROP COLUMN source");
+
+                // 5) UPDATE/DELETE are unsupported on streaming devices; demonstrate expected failures.
+                try {
+                    ddl.execute("UPDATE events SET event_type = 'X' WHERE user_id = 'user-10'");
+                } catch (SQLException e) {
+                    System.out.println("Expected UPDATE failure on Streaming device: " + e.getMessage());
+                }
+                try {
+                    ddl.execute("DELETE FROM events WHERE user_id = 'user-11'");
+                } catch (SQLException e) {
+                    System.out.println("Expected DELETE failure on Streaming device: " + e.getMessage());
+                }
+            }
+
+            // 6) DROP TABLE (different table) via Stream API
+            stream.dropTable("temp_events_archive");
+        }
+
+        Streaming.closeDevice(Path.of("sample_stream_api.db"));
+    }
+}

--- a/logger/samples/java/SyncLiteStreamingApp.java
+++ b/logger/samples/java/SyncLiteStreamingApp.java
@@ -1,0 +1,92 @@
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import io.synclite.logger.Streaming;
+
+/**
+ * Streaming device sample.
+ *
+ * Streaming devices are for append-first event capture. The normal pattern is
+ * to define the stream shape and keep inserting new records that represent
+ * events, messages, or telemetry.
+ *
+ * This is not a mutable relational surface. INSERT is the primary data path,
+ * selected DDL is supported for schema evolution, and UPDATE or DELETE are
+ * expected to fail because previously emitted events are not meant to be edited
+ * in place.
+ */
+public class SyncLiteStreamingApp {
+
+    public static void main(String[] args) throws ClassNotFoundException, SQLException {
+        Class.forName("io.synclite.logger.Streaming");
+        Path dbPath = Path.of("sample_streaming.db");
+        Streaming.initialize(dbPath, Path.of("synclite_logger.conf"));
+
+        try (Connection conn = DriverManager.getConnection("jdbc:synclite_streaming:sample_streaming.db")) {
+            try (Statement stmt = conn.createStatement()) {
+                // 1) CREATE TABLE
+                stmt.execute("CREATE TABLE IF NOT EXISTS events(ts BIGINT, event_type TEXT, user_id TEXT)");
+
+                // Separate table to demonstrate DROP TABLE on a different table.
+                stmt.execute("CREATE TABLE IF NOT EXISTS temp_events_archive(id INT, note TEXT)");
+            }
+
+            // 2) INSERT
+            try (PreparedStatement pstmt = conn.prepareStatement("INSERT INTO events VALUES(?, ?, ?)");) {
+                pstmt.setLong(1, System.currentTimeMillis());
+                pstmt.setString(2, "CLICK");
+                pstmt.setString(3, "user-1");
+                pstmt.addBatch();
+
+                pstmt.setLong(1, System.currentTimeMillis());
+                pstmt.setString(2, "VIEW");
+                pstmt.setString(3, "user-2");
+                pstmt.addBatch();
+
+                pstmt.executeBatch();
+            }
+
+            try (Statement schema = conn.createStatement()) {
+                // 3) ALTER TABLE ADD COLUMN
+                schema.execute("ALTER TABLE events ADD COLUMN source TEXT");
+            }
+
+            try (PreparedStatement insertWithSource = conn.prepareStatement("INSERT INTO events VALUES(?, ?, ?, ?)")) {
+                insertWithSource.setLong(1, System.currentTimeMillis());
+                insertWithSource.setString(2, "PURCHASE");
+                insertWithSource.setString(3, "user-3");
+                insertWithSource.setString(4, "mobile");
+                insertWithSource.executeUpdate();
+            }
+
+            try (Statement schema = conn.createStatement()) {
+                // 4) ALTER TABLE DROP COLUMN
+                schema.execute("ALTER TABLE events DROP COLUMN source");
+
+                // 5) DROP TABLE on different table
+                schema.execute("DROP TABLE IF EXISTS temp_events_archive");
+            }
+
+            // Streaming device supports DDL and INSERT only; UPDATE/DELETE are expected to fail.
+            try (Statement unsupported = conn.createStatement()) {
+                try {
+                    unsupported.execute("UPDATE events SET event_type = 'X' WHERE user_id = 'user-1'");
+                } catch (SQLException e) {
+                    System.out.println("Expected UPDATE failure on Streaming device: " + e.getMessage());
+                }
+
+                try {
+                    unsupported.execute("DELETE FROM events WHERE user_id = 'user-2'");
+                } catch (SQLException e) {
+                    System.out.println("Expected DELETE failure on Streaming device: " + e.getMessage());
+                }
+            }
+        }
+
+        Streaming.closeDevice(Path.of("sample_streaming.db"));
+    }
+}

--- a/logger/samples/java/SyncLiteStreamingApp.java
+++ b/logger/samples/java/SyncLiteStreamingApp.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2024 mahendra.chavan@synclite.io, all rights reserved.
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.  See the License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
 import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.DriverManager;

--- a/logger/samples/java/SyncliteDeviceApp.java
+++ b/logger/samples/java/SyncliteDeviceApp.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2024 mahendra.chavan@synclite.io, all rights reserved.
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.  See the License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
 import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.DriverManager;

--- a/logger/samples/java/SyncliteDeviceApp.java
+++ b/logger/samples/java/SyncliteDeviceApp.java
@@ -1,0 +1,104 @@
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import io.synclite.logger.SQLite;
+
+/**
+ * SQL device sample.
+ *
+ * A SQL device accepts general SQL and logs the statements as written. During
+ * consolidation those statements are replayed on a replica, CDC is derived from
+ * the replica, and that downstream change stream is then applied to the
+ * configured destinations.
+ *
+ * That makes SQL devices the right fit for full relational behavior, including
+ * statements whose effects must be computed by the database engine, such as
+ * INSERT INTO ... SELECT ... FROM .... Store devices are narrower: they focus on
+ * operations where the changed data is already explicit in the request so it can
+ * be pushed directly downstream without needing statement replay plus CDC.
+ */
+public class SyncliteDeviceApp {
+
+    public static void main(String[] args) throws ClassNotFoundException, SQLException {
+        appStartup();
+        SyncliteDeviceApp app = new SyncliteDeviceApp();
+        app.runBusinessLogic();
+    }
+
+    public static void appStartup() throws SQLException, ClassNotFoundException {
+        // SQL-device default: SQLite.
+        // Replace for other SQL-device engines:
+        // 1) Driver class: io.synclite.logger.SQLite -> Derby, DuckDB, H2, HyperSQL
+        // 2) Initialize call: SQLite.initialize(...) -> <Engine>.initialize(...)
+        // 3) JDBC URL prefix in runBusinessLogic():
+        //    jdbc:synclite_sqlite: -> jdbc:synclite_derby:, jdbc:synclite_duckdb:, jdbc:synclite_h2:, jdbc:synclite_hsqldb:
+        Class.forName("io.synclite.logger.SQLite");
+        Path dbPath = Path.of("sample_txn_sqlite.db");
+        SQLite.initialize(dbPath, Path.of("synclite_logger.conf"));
+    }
+
+    public void runBusinessLogic() throws SQLException {
+        try (Connection conn = DriverManager.getConnection("jdbc:synclite_sqlite:sample_txn_sqlite.db")) {
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute("CREATE TABLE IF NOT EXISTS feedback(rating INT, comment TEXT)");
+                // Separate table for explicit DROP TABLE demonstration.
+                stmt.execute("CREATE TABLE IF NOT EXISTS temp_feedback_archive(id INT, note TEXT)");
+                stmt.execute("INSERT INTO feedback VALUES(3, 'Good product')");
+            }
+
+            conn.setAutoCommit(false);
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute("UPDATE feedback SET comment = 'Better product' WHERE rating = 3");
+                stmt.execute("INSERT INTO feedback VALUES (1, 'Poor product')");
+                stmt.execute("DELETE FROM feedback WHERE rating = 1");
+            }
+            conn.commit();
+            conn.setAutoCommit(true);
+
+            try (PreparedStatement pstmt = conn.prepareStatement("INSERT INTO feedback VALUES(?, ?)")) {
+                pstmt.setInt(1, 4);
+                pstmt.setString(2, "Excellent Product");
+                pstmt.addBatch();
+
+                pstmt.setInt(1, 5);
+                pstmt.setString(2, "Outstanding Product");
+                pstmt.addBatch();
+
+                pstmt.executeBatch();
+            }
+
+            try (Statement schema = conn.createStatement()) {
+                // ALTER TABLE ADD COLUMN
+                schema.execute("ALTER TABLE feedback ADD COLUMN source TEXT");
+            }
+
+            try (PreparedStatement updateSource = conn.prepareStatement("UPDATE feedback SET source = ? WHERE rating = ?")) {
+                updateSource.setString(1, "web");
+                updateSource.setInt(2, 3);
+                updateSource.executeUpdate();
+            }
+
+            try (Statement schema = conn.createStatement()) {
+                // ALTER TABLE DROP COLUMN
+                schema.execute("ALTER TABLE feedback DROP COLUMN source");
+
+                // DROP TABLE on a different table
+                schema.execute("DROP TABLE IF EXISTS temp_feedback_archive");
+            }
+
+            try (Statement query = conn.createStatement();
+                 ResultSet rs = query.executeQuery("SELECT rating, comment FROM feedback ORDER BY rating")) {
+                while (rs.next()) {
+                    System.out.println("rating=" + rs.getInt("rating") + ", comment=" + rs.getString("comment"));
+                }
+            }
+        }
+
+        SQLite.closeDevice(Path.of("sample_txn_sqlite.db"));
+    }
+}

--- a/logger/samples/python/JPype/README.md
+++ b/logger/samples/python/JPype/README.md
@@ -1,0 +1,22 @@
+# JPype Samples
+
+These samples call SyncLite Java APIs directly from Python through JPype.
+
+Install:
+
+pip install jpype1
+
+Run example:
+
+python JPype/SyncLiteStoreAPIApp.py
+
+API-style samples in this folder:
+
+- SyncLiteStoreAPIApp.py
+- SyncLiteStreamAPIApp.py
+- SyncLiteKafkaProduceAPIApp.py
+- SyncLiteJedisAPIApp.py
+
+Notes:
+- Replace `synclite-logger-<version>.jar` with your actual jar name/path.
+- Keep `synclite_logger.conf` in the current working directory.

--- a/logger/samples/python/JPype/SyncLiteAppenderDeviceApp.py
+++ b/logger/samples/python/JPype/SyncLiteAppenderDeviceApp.py
@@ -1,0 +1,36 @@
+"""
+Appender device sample via JPype.
+
+Appender devices are aimed at write-heavy ingest workloads where the dominant
+operation is appending new rows. They keep the calling pattern simple and focus
+on durable INSERT-style logging.
+
+Compared to a SQL device, this is intentionally narrower. If the workload needs
+arbitrary SQL semantics and replay on a replica, use a SQL device instead.
+"""
+
+from _common import start_jvm
+
+
+def main():
+    start_jvm()
+
+    from java.nio.file import Path
+    from java.sql import DriverManager
+    from io.synclite.logger import SQLiteAppender
+
+    db_path = Path.of("sample_appender_sqlite_jpype.db")
+    SQLiteAppender.initialize(db_path, Path.of("synclite_logger.conf"))
+
+    conn = DriverManager.getConnection("jdbc:synclite_sqlite_appender:sample_appender_sqlite_jpype.db")
+    stmt = conn.createStatement()
+    stmt.execute("CREATE TABLE IF NOT EXISTS feedback(rating INT, comment TEXT)")
+    stmt.execute("INSERT INTO feedback VALUES(4, 'Excellent Product')")
+    stmt.execute("INSERT INTO feedback VALUES(5, 'Outstanding Product')")
+    stmt.close()
+    conn.close()
+    SQLiteAppender.closeDevice(db_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/logger/samples/python/JPype/SyncLiteAppenderDeviceApp.py
+++ b/logger/samples/python/JPype/SyncLiteAppenderDeviceApp.py
@@ -1,3 +1,16 @@
+# Copyright (c) 2024 mahendra.chavan@synclite.io, all rights reserved.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied.  See the License for the specific language governing permissions and limitations
+# under the License.
+#
 """
 Appender device sample via JPype.
 

--- a/logger/samples/python/JPype/SyncLiteJedisAPIApp.py
+++ b/logger/samples/python/JPype/SyncLiteJedisAPIApp.py
@@ -1,3 +1,16 @@
+# Copyright (c) 2024 mahendra.chavan@synclite.io, all rights reserved.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied.  See the License for the specific language governing permissions and limitations
+# under the License.
+#
 """
 Jedis API sample via JPype.
 

--- a/logger/samples/python/JPype/SyncLiteJedisAPIApp.py
+++ b/logger/samples/python/JPype/SyncLiteJedisAPIApp.py
@@ -1,0 +1,92 @@
+"""
+Jedis API sample via JPype.
+
+This sample demonstrates a broader Redis-style command surface on top of the
+SyncLite-backed Jedis wrapper, including strings, hashes, lists, sets, sorted
+sets, and key lifecycle operations.
+
+The sample uses managed builder mode, so SQLiteStore initialize/open/close is
+handled by Jedis itself.
+"""
+
+from _common import start_jvm
+
+
+def main():
+    start_jvm()
+
+    from java.nio.file import Path
+    from java.util import HashMap
+    from io.synclite.logger import Jedis
+
+    db_path = Path.of("sample_jedis_store_jpype.db")
+
+    jedis = Jedis.builder(db_path, Path.of("synclite_logger.conf"), "jedis-sample-jpype") \
+        .host("localhost") \
+        .port(6379) \
+        .build()
+
+    try:
+        # Clear keys used by this sample so repeated runs stay deterministic.
+        jedis.del(
+            "sample:user:1:name",
+            "sample:user:2:name",
+            "sample:user:3:name",
+            "sample:session:42",
+            "sample:queue",
+            "sample:tags",
+            "sample:leaderboard",
+            "sample:tmp",
+            "sample:tmp:renamed",
+        )
+
+        # 1) Strings
+        jedis.set("sample:user:1:name", "Alice")
+        jedis.mset("sample:user:2:name", "Bob", "sample:user:3:name", "Carol")
+        print("GET sample:user:1:name =", jedis.get("sample:user:1:name"))
+        print("MGET users =", jedis.mget("sample:user:2:name", "sample:user:3:name"))
+
+        # 2) Hashes
+        session = HashMap()
+        session.put("token", "abc123")
+        session.put("status", "active")
+        session.put("region", "us-east")
+        jedis.hset("sample:session:42", session)
+        print("HGET token =", jedis.hget("sample:session:42", "token"))
+        print("HGETALL session =", jedis.hgetAll("sample:session:42"))
+        jedis.hdel("sample:session:42", "region")
+
+        # 3) Lists
+        jedis.rpush("sample:queue", "job-1", "job-2")
+        jedis.lpush("sample:queue", "job-0")
+        print("LRANGE queue =", jedis.lrange("sample:queue", 0, -1))
+        print("LPOP queue =", jedis.lpop("sample:queue"))
+        print("RPOP queue =", jedis.rpop("sample:queue"))
+
+        # 4) Sets
+        jedis.sadd("sample:tags", "etl", "cdc", "ops")
+        jedis.srem("sample:tags", "ops")
+        print("SMEMBERS tags =", jedis.smembers("sample:tags"))
+
+        # 5) Sorted sets
+        jedis.zadd("sample:leaderboard", 9.5, "alice")
+        jedis.zadd("sample:leaderboard", 8.0, "bob")
+        jedis.zadd("sample:leaderboard", 9.8, "carol")
+        jedis.zincrby("sample:leaderboard", 0.3, "bob")
+        print("ZRANGE leaderboard =", jedis.zrange("sample:leaderboard", 0, -1))
+        print("ZSCORE bob =", jedis.zscore("sample:leaderboard", "bob"))
+
+        # 6) Key lifecycle
+        jedis.set("sample:tmp", "ephemeral")
+        jedis.expire("sample:tmp", 60)
+        print("TTL sample:tmp =", jedis.ttl("sample:tmp"))
+        jedis.rename("sample:tmp", "sample:tmp:renamed")
+        jedis.persist("sample:tmp:renamed")
+        jedis.del("sample:tmp:renamed")
+
+    finally:
+        jedis.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/logger/samples/python/JPype/SyncLiteKafkaProduceAPIApp.py
+++ b/logger/samples/python/JPype/SyncLiteKafkaProduceAPIApp.py
@@ -1,3 +1,16 @@
+# Copyright (c) 2024 mahendra.chavan@synclite.io, all rights reserved.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied.  See the License for the specific language governing permissions and limitations
+# under the License.
+#
 """
 KafkaProducer API sample via JPype.
 

--- a/logger/samples/python/JPype/SyncLiteKafkaProduceAPIApp.py
+++ b/logger/samples/python/JPype/SyncLiteKafkaProduceAPIApp.py
@@ -1,0 +1,36 @@
+"""
+KafkaProducer API sample via JPype.
+
+This sample shows producer-style publishing through the SyncLite KafkaProducer
+Java API from Python. The application deals with records and topics directly
+instead of modeling messages as rows through a SQL surface.
+
+That makes it the API-oriented counterpart to the SQL-based streaming samples.
+Use this path when the application is already structured around Kafka producer
+semantics and you want SyncLite persistence behind that API.
+"""
+
+from _common import start_jvm
+
+
+def main():
+    start_jvm()
+
+    from java.util import Properties
+    from org.apache.kafka.clients.producer import ProducerRecord
+    from io.synclite.logger import KafkaProducer
+
+    props = Properties()
+    props.put("bootstrap.servers", "localhost:9092")
+    props.put("device-path", "sample_kafka_api_jpype.db")
+    props.put("device-type", "STREAMING")
+
+    producer = KafkaProducer(props)
+    producer.send(ProducerRecord("orders", "order-1", "{\"status\":\"created\"}"))
+    producer.send(ProducerRecord("orders", "order-2", "{\"status\":\"confirmed\"}"))
+    producer.flush()
+    producer.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/logger/samples/python/JPype/SyncLiteStoreAPIApp.py
+++ b/logger/samples/python/JPype/SyncLiteStoreAPIApp.py
@@ -1,3 +1,16 @@
+# Copyright (c) 2024 mahendra.chavan@synclite.io, all rights reserved.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied.  See the License for the specific language governing permissions and limitations
+# under the License.
+#
 """
 Store API sample via JPype.
 

--- a/logger/samples/python/JPype/SyncLiteStoreAPIApp.py
+++ b/logger/samples/python/JPype/SyncLiteStoreAPIApp.py
@@ -1,0 +1,74 @@
+"""
+Store API sample via JPype.
+
+This sample uses the Store API rather than issuing raw SQL strings for every
+change. It targets the same store-device model as the JDBC store sample:
+mutable operations whose row data is explicit enough to be applied directly to
+downstream destinations.
+
+The contrast with a SQL device is semantic, not just syntactic. A SQL device
+can log arbitrary SQL and rely on replay plus CDC extraction later. The Store
+API is intentionally centered on direct CRUD-style changes, so patterns such as
+INSERT INTO ... SELECT ... are outside its core model. Column drop is still
+shown through JDBC DDL because Store API has no direct drop-column helper.
+"""
+
+from _common import start_jvm
+
+
+def main():
+    start_jvm()
+
+    from java.nio.file import Path
+    from java.sql import DriverManager
+    from java.util import LinkedHashMap, HashMap, ArrayList
+    from io.synclite.logger import SQLiteStore
+
+    db_path = Path.of("sample_store_api_jpype.db")
+    SQLiteStore.initialize(db_path, Path.of("synclite_logger.conf"))
+
+    store = SQLiteStore.open(db_path)
+
+    cols = LinkedHashMap()
+    cols.put("id", "INTEGER PRIMARY KEY")
+    cols.put("name", "TEXT")
+    cols.put("score", "INTEGER")
+    store.createTable("players", cols)
+
+    archive_cols = LinkedHashMap()
+    archive_cols.put("id", "INTEGER")
+    archive_cols.put("note", "TEXT")
+    store.createTable("temp_players_archive", archive_cols)
+
+    row1 = HashMap()
+    row1.put("id", 1)
+    row1.put("name", "Alice")
+    row1.put("score", 100)
+    store.insert("players", row1)
+
+    set_vals = HashMap()
+    set_vals.put("score", 250)
+    where_vals = HashMap()
+    where_vals.put("id", 1)
+    store.update("players", set_vals, where_vals)
+
+    set_email = HashMap()
+    set_email.put("email", "alice@example.com")
+    store.update("players", set_email, where_vals)
+
+    # Store API does not provide an explicit drop-column method.
+    conn = DriverManager.getConnection("jdbc:synclite_sqlite_store:sample_store_api_jpype.db")
+    stmt = conn.createStatement()
+    stmt.execute("ALTER TABLE players DROP COLUMN email")
+    stmt.close()
+    conn.close()
+
+    store.dropTable("temp_players_archive")
+    rows = store.selectAll("players")
+    print("Store API rows count:", rows.size())
+    store.close()
+    SQLiteStore.closeDevice(db_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/logger/samples/python/JPype/SyncLiteStoreDeviceApp.py
+++ b/logger/samples/python/JPype/SyncLiteStoreDeviceApp.py
@@ -1,0 +1,44 @@
+"""
+Store device sample via JPype and JDBC SQL.
+
+A store device is for mutable operational data where the row changes are
+explicit in the operation itself. That lets SyncLite apply those changes
+directly to downstream destinations instead of replaying the SQL on a replica
+and deriving CDC afterward.
+
+This is the core difference from a SQL device. A SQL device can log arbitrary
+SQL and rely on replay plus CDC extraction later. A store device is narrower,
+so patterns such as INSERT INTO target SELECT ... FROM source are not its core
+model because the inserted rows are not already present in the request.
+
+
+def main():
+    start_jvm()
+
+    from java.nio.file import Path
+    from java.sql import DriverManager
+    from io.synclite.logger import SQLiteStore
+
+    db_path = Path.of("sample_store_sqlite_jpype.db")
+    SQLiteStore.initialize(db_path, Path.of("synclite_logger.conf"))
+
+    conn = DriverManager.getConnection("jdbc:synclite_sqlite_store:sample_store_sqlite_jpype.db")
+    stmt = conn.createStatement()
+    stmt.execute("CREATE TABLE IF NOT EXISTS users(id INT PRIMARY KEY, name TEXT)")
+    stmt.execute("CREATE TABLE IF NOT EXISTS temp_users_archive(id INT, note TEXT)")
+    # CRUD + schema evolution on mutable data.
+    stmt.execute("INSERT INTO users VALUES(1, 'Alice')")
+    stmt.execute("INSERT INTO users VALUES(2, 'Bob')")
+    stmt.execute("UPDATE users SET name='Alice Cooper' WHERE id=1")
+    stmt.execute("DELETE FROM users WHERE id=2")
+    stmt.execute("ALTER TABLE users ADD COLUMN email TEXT")
+    stmt.execute("UPDATE users SET email='alice@example.com' WHERE id=1")
+    stmt.execute("ALTER TABLE users DROP COLUMN email")
+    stmt.execute("DROP TABLE IF EXISTS temp_users_archive")
+    stmt.close()
+    conn.close()
+    SQLiteStore.closeDevice(db_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/logger/samples/python/JPype/SyncLiteStoreDeviceApp.py
+++ b/logger/samples/python/JPype/SyncLiteStoreDeviceApp.py
@@ -1,3 +1,16 @@
+# Copyright (c) 2024 mahendra.chavan@synclite.io, all rights reserved.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied.  See the License for the specific language governing permissions and limitations
+# under the License.
+#
 """
 Store device sample via JPype and JDBC SQL.
 

--- a/logger/samples/python/JPype/SyncLiteStreamAPIApp.py
+++ b/logger/samples/python/JPype/SyncLiteStreamAPIApp.py
@@ -1,0 +1,75 @@
+"""
+Stream API sample via JPype.
+
+This sample uses the Stream API for append-oriented event ingestion. It is the
+API-level counterpart to the streaming-device JDBC sample and is meant for
+workloads where new records are emitted continuously.
+
+The distinction from Store API is that Stream API is not modeling mutable
+business rows. It models event flow. INSERT remains the core operation,
+selected DDL is available for schema evolution, and UPDATE or DELETE are
+intentionally unsupported.
+"""
+
+from _common import start_jvm
+
+
+def main():
+    start_jvm()
+
+    from java.nio.file import Path
+    from java.sql import DriverManager, SQLException
+    from java.util import LinkedHashMap, HashMap
+    from io.synclite.logger import Streaming, SyncLiteStream
+
+    db_path = Path.of("sample_stream_api_jpype.db")
+    Streaming.initialize(db_path, Path.of("synclite_logger.conf"))
+
+    stream = SyncLiteStream.open(db_path)
+
+    cols = LinkedHashMap()
+    cols.put("ts", "BIGINT")
+    cols.put("event_type", "TEXT")
+    cols.put("user_id", "TEXT")
+    stream.createTable("events", cols)
+
+    archive_cols = LinkedHashMap()
+    archive_cols.put("id", "INT")
+    archive_cols.put("note", "TEXT")
+    stream.createTable("temp_events_archive", archive_cols)
+
+    row = HashMap()
+    row.put("ts", 1001)
+    row.put("event_type", "SIGNUP")
+    row.put("user_id", "user-10")
+    stream.insert("events", row)
+
+    row2 = HashMap()
+    row2.put("ts", 1002)
+    row2.put("event_type", "PURCHASE")
+    row2.put("user_id", "user-11")
+    row2.put("source", "web")
+    stream.insert("events", row2)
+
+    # Stream API also relies on JDBC for drop-column in this sample.
+    conn = DriverManager.getConnection("jdbc:synclite_streaming:sample_stream_api_jpype.db")
+    stmt = conn.createStatement()
+    stmt.execute("ALTER TABLE events DROP COLUMN source")
+    try:
+        stmt.execute("UPDATE events SET event_type='X' WHERE user_id='user-10'")
+    except SQLException as e:
+        print("Expected UPDATE failure on Streaming device:", e.getMessage())
+    try:
+        stmt.execute("DELETE FROM events WHERE user_id='user-11'")
+    except SQLException as e:
+        print("Expected DELETE failure on Streaming device:", e.getMessage())
+    stmt.close()
+    conn.close()
+
+    stream.dropTable("temp_events_archive")
+    stream.close()
+    Streaming.closeDevice(db_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/logger/samples/python/JPype/SyncLiteStreamAPIApp.py
+++ b/logger/samples/python/JPype/SyncLiteStreamAPIApp.py
@@ -1,3 +1,16 @@
+# Copyright (c) 2024 mahendra.chavan@synclite.io, all rights reserved.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied.  See the License for the specific language governing permissions and limitations
+# under the License.
+#
 """
 Stream API sample via JPype.
 

--- a/logger/samples/python/JPype/SyncLiteStreamingApp.py
+++ b/logger/samples/python/JPype/SyncLiteStreamingApp.py
@@ -1,3 +1,16 @@
+# Copyright (c) 2024 mahendra.chavan@synclite.io, all rights reserved.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied.  See the License for the specific language governing permissions and limitations
+# under the License.
+#
 """
 Streaming device sample via JPype and JDBC SQL.
 

--- a/logger/samples/python/JPype/SyncLiteStreamingApp.py
+++ b/logger/samples/python/JPype/SyncLiteStreamingApp.py
@@ -1,0 +1,54 @@
+"""
+Streaming device sample via JPype and JDBC SQL.
+
+Streaming devices are for append-first event capture. The normal pattern is to
+define the stream shape and keep inserting new records that represent events,
+messages, or telemetry.
+
+This is not a mutable relational surface. INSERT is the primary data path,
+selected DDL is supported for schema evolution, and UPDATE or DELETE are shown
+as expected failures.
+"""
+
+from _common import start_jvm
+
+
+def main():
+    start_jvm()
+
+    from java.nio.file import Path
+    from java.sql import DriverManager, SQLException
+    from io.synclite.logger import Streaming
+
+    db_path = Path.of("sample_streaming_jpype.db")
+    Streaming.initialize(db_path, Path.of("synclite_logger.conf"))
+
+    conn = DriverManager.getConnection("jdbc:synclite_streaming:sample_streaming_jpype.db")
+    stmt = conn.createStatement()
+    stmt.execute("CREATE TABLE IF NOT EXISTS events(ts BIGINT, event_type TEXT, user_id TEXT)")
+    stmt.execute("CREATE TABLE IF NOT EXISTS temp_events_archive(id INT, note TEXT)")
+    stmt.execute("INSERT INTO events VALUES(1001, 'CLICK', 'user-1')")
+    stmt.execute("INSERT INTO events VALUES(1002, 'VIEW', 'user-2')")
+    stmt.execute("ALTER TABLE events ADD COLUMN source TEXT")
+    stmt.execute("INSERT INTO events VALUES(1003, 'PURCHASE', 'user-3', 'mobile')")
+    stmt.execute("ALTER TABLE events DROP COLUMN source")
+    stmt.execute("DROP TABLE IF EXISTS temp_events_archive")
+
+    # By design, streaming device does not support row mutation/deletion.
+    try:
+        stmt.execute("UPDATE events SET event_type='X' WHERE user_id='user-1'")
+    except SQLException as e:
+        print("Expected UPDATE failure on Streaming device:", e.getMessage())
+
+    try:
+        stmt.execute("DELETE FROM events WHERE user_id='user-2'")
+    except SQLException as e:
+        print("Expected DELETE failure on Streaming device:", e.getMessage())
+
+    stmt.close()
+    conn.close()
+    Streaming.closeDevice(db_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/logger/samples/python/JPype/SyncliteDeviceApp.py
+++ b/logger/samples/python/JPype/SyncliteDeviceApp.py
@@ -1,0 +1,49 @@
+"""
+SQL device sample via JPype.
+
+A SQL device accepts general SQL and logs the statements as written. During
+consolidation those statements are replayed on a replica, CDC is derived from
+the replica, and that change stream is then applied to downstream destinations.
+
+That makes SQL devices the right fit for full relational behavior, including
+statements such as INSERT INTO ... SELECT ... FROM .... Store devices are
+narrower and focus on operations where the changed data is already explicit in
+the request.
+"""
+
+from _common import start_jvm
+
+
+def main():
+    start_jvm()
+
+    from java.nio.file import Path
+    from java.sql import DriverManager
+    from io.synclite.logger import SQLite
+
+    db_path = Path.of("sample_txn_sqlite_jpype.db")
+    SQLite.initialize(db_path, Path.of("synclite_logger.conf"))
+
+    conn = DriverManager.getConnection("jdbc:synclite_sqlite:sample_txn_sqlite_jpype.db")
+    stmt = conn.createStatement()
+    stmt.execute("CREATE TABLE IF NOT EXISTS feedback(rating INT, comment TEXT)")
+    stmt.execute("CREATE TABLE IF NOT EXISTS temp_feedback_archive(id INT, note TEXT)")
+    stmt.execute("INSERT INTO feedback VALUES(3, 'Good product')")
+    # SQL device transaction control is explicit and familiar.
+    conn.setAutoCommit(False)
+    stmt.execute("UPDATE feedback SET comment='Better product' WHERE rating=3")
+    stmt.execute("INSERT INTO feedback VALUES(1, 'Poor product')")
+    stmt.execute("DELETE FROM feedback WHERE rating=1")
+    conn.commit()
+    conn.setAutoCommit(True)
+    stmt.execute("ALTER TABLE feedback ADD COLUMN source TEXT")
+    stmt.execute("UPDATE feedback SET source='web' WHERE rating=3")
+    stmt.execute("ALTER TABLE feedback DROP COLUMN source")
+    stmt.execute("DROP TABLE IF EXISTS temp_feedback_archive")
+    stmt.close()
+    conn.close()
+    SQLite.closeDevice(db_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/logger/samples/python/JPype/SyncliteDeviceApp.py
+++ b/logger/samples/python/JPype/SyncliteDeviceApp.py
@@ -1,3 +1,16 @@
+# Copyright (c) 2024 mahendra.chavan@synclite.io, all rights reserved.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied.  See the License for the specific language governing permissions and limitations
+# under the License.
+#
 """
 SQL device sample via JPype.
 

--- a/logger/samples/python/JPype/_common.py
+++ b/logger/samples/python/JPype/_common.py
@@ -1,3 +1,16 @@
+# Copyright (c) 2024 mahendra.chavan@synclite.io, all rights reserved.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied.  See the License for the specific language governing permissions and limitations
+# under the License.
+#
 """
 Shared JPype bootstrap helper.
 

--- a/logger/samples/python/JPype/_common.py
+++ b/logger/samples/python/JPype/_common.py
@@ -1,0 +1,18 @@
+"""
+Shared JPype bootstrap helper.
+
+This helper starts the JVM once and makes the SyncLite Java classes available
+directly from Python. All JPype samples build on that bridge before they open
+devices or invoke SyncLite APIs.
+
+The important distinction from JayDeBeApi is that JPype exposes the actual Java
+API objects, while JayDeBeApi stays at the JDBC and SQL layer.
+"""
+
+import jpype
+import jpype.imports
+
+
+def start_jvm(jar_path="synclite-logger-<version>.jar"):
+    if not jpype.isJVMStarted():
+        jpype.startJVM(classpath=[jar_path])

--- a/logger/samples/python/JayDeBeApi/README.md
+++ b/logger/samples/python/JayDeBeApi/README.md
@@ -1,0 +1,15 @@
+# JayDeBeApi Samples
+
+These samples use JayDeBeApi and SQL statements over SyncLite JDBC URLs.
+
+Install:
+
+pip install JayDeBeApi
+
+Run example:
+
+python JayDeBeApi/SyncliteDeviceApp.py
+
+Notes:
+- Replace `synclite-logger-<version>.jar` with your actual jar name/path.
+- Keep `synclite_logger.conf` in the current working directory.

--- a/logger/samples/python/JayDeBeApi/SyncLiteAppenderDeviceApp.py
+++ b/logger/samples/python/JayDeBeApi/SyncLiteAppenderDeviceApp.py
@@ -1,3 +1,16 @@
+# Copyright (c) 2024 mahendra.chavan@synclite.io, all rights reserved.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied.  See the License for the specific language governing permissions and limitations
+# under the License.
+#
 """
 Appender device sample (JayDeBeApi + JDBC URL).
 

--- a/logger/samples/python/JayDeBeApi/SyncLiteAppenderDeviceApp.py
+++ b/logger/samples/python/JayDeBeApi/SyncLiteAppenderDeviceApp.py
@@ -1,0 +1,38 @@
+"""
+Appender device sample (JayDeBeApi + JDBC URL).
+
+Appender devices are aimed at write-heavy ingest workloads where the dominant
+operation is appending new rows. They keep the calling pattern simple and focus
+on durable INSERT-style logging.
+
+Compared to a SQL device, this is intentionally narrower. If the workload needs
+arbitrary SQL semantics and replay on a replica, use a SQL device instead.
+"""
+
+import jaydebeapi
+
+# Appender default: SQLiteAppender.
+# Replace for other appender engines:
+# 1) Driver class: io.synclite.logger.SQLiteAppender -> DerbyAppender, DuckDBAppender, H2Appender, HyperSQLAppender
+# 2) JDBC URL prefix:
+#    jdbc:synclite_sqlite_appender: -> jdbc:synclite_derby_appender:, jdbc:synclite_duckdb_appender:, jdbc:synclite_h2_appender:, jdbc:synclite_hsqldb_appender:
+
+props = {
+    "config": "synclite_logger.conf",
+    "device-name": "appender-sample"
+}
+
+conn = jaydebeapi.connect(
+    "io.synclite.logger.SQLiteAppender",
+    "jdbc:synclite_sqlite_appender:sample_appender_sqlite_py.db",
+    props,
+    "synclite-logger-<version>.jar"
+)
+
+cur = conn.cursor()
+cur.execute("CREATE TABLE IF NOT EXISTS feedback(rating INT, comment TEXT)")
+# Keep this sample insert-focused to reflect appender-style usage.
+cur.executemany("INSERT INTO feedback VALUES(?, ?)", [[4, "Excellent Product"], [5, "Outstanding Product"]])
+cur.execute("close database sample_appender_sqlite_py.db")
+cur.close()
+conn.close()

--- a/logger/samples/python/JayDeBeApi/SyncLiteKafkaProduceApp.py
+++ b/logger/samples/python/JayDeBeApi/SyncLiteKafkaProduceApp.py
@@ -1,0 +1,38 @@
+"""
+Kafka-produce style sample using a Streaming device (JayDeBeApi).
+
+This sample models Kafka-style messages as rows in a streaming table. It is the
+SQL-oriented Python equivalent when the bridge is JDBC-based rather than direct
+Java API access.
+
+It is not using the KafkaProducer API itself. If you want direct Java producer
+semantics from Python, the JPype KafkaProducer sample is the better match.
+"""
+
+import json
+import time
+import jaydebeapi
+
+# Python equivalent of Kafka produce flow using a streaming table.
+props = {
+    "config": "synclite_logger.conf",
+    "device-name": "kafka-produce-sample"
+}
+
+conn = jaydebeapi.connect(
+    "io.synclite.logger.Streaming",
+    "jdbc:synclite_streaming:sample_kafka_py.db",
+    props,
+    "synclite-logger-<version>.jar"
+)
+
+cur = conn.cursor()
+cur.execute("CREATE TABLE IF NOT EXISTS kafka_messages(ts BIGINT, topic TEXT, msg_key TEXT, msg_value TEXT)")
+messages = [
+    [int(time.time() * 1000), "orders", "order-1", json.dumps({"status": "created"})],
+    [int(time.time() * 1000), "orders", "order-2", json.dumps({"status": "confirmed"})],
+]
+cur.executemany("INSERT INTO kafka_messages VALUES(?, ?, ?, ?)", messages)
+cur.execute("close database sample_kafka_py.db")
+cur.close()
+conn.close()

--- a/logger/samples/python/JayDeBeApi/SyncLiteKafkaProduceApp.py
+++ b/logger/samples/python/JayDeBeApi/SyncLiteKafkaProduceApp.py
@@ -1,3 +1,16 @@
+# Copyright (c) 2024 mahendra.chavan@synclite.io, all rights reserved.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied.  See the License for the specific language governing permissions and limitations
+# under the License.
+#
 """
 Kafka-produce style sample using a Streaming device (JayDeBeApi).
 

--- a/logger/samples/python/JayDeBeApi/SyncLiteStoreDeviceApp.py
+++ b/logger/samples/python/JayDeBeApi/SyncLiteStoreDeviceApp.py
@@ -1,0 +1,44 @@
+"""
+Store device sample (JayDeBeApi + JDBC URL).
+
+A store device is for mutable operational data where the row changes are
+explicit in the operation itself. That lets SyncLite apply those changes
+directly to downstream destinations instead of replaying the SQL on a replica
+and deriving CDC afterward.
+
+This is the core difference from a SQL device. A SQL device can log arbitrary
+SQL and rely on replay plus CDC extraction later. A store device is narrower,
+so patterns such as INSERT INTO target SELECT ... FROM source are not its core
+model because the inserted rows are not already present in the request.
+"""
+
+import jaydebeapi
+
+props = {
+    "config": "synclite_logger.conf",
+    "device-name": "store-device-sample"
+}
+
+conn = jaydebeapi.connect(
+    "io.synclite.logger.SQLiteStore",
+    "jdbc:synclite_sqlite_store:sample_store_sqlite_py.db",
+    props,
+    "synclite-logger-<version>.jar"
+)
+
+cur = conn.cursor()
+cur.execute("CREATE TABLE IF NOT EXISTS users(id INT PRIMARY KEY, name TEXT)")
+cur.execute("CREATE TABLE IF NOT EXISTS temp_users_archive(id INT, note TEXT)")
+# Full CRUD + schema evolution flow for a mutable table.
+cur.executemany("INSERT INTO users VALUES(?, ?)", [[1, "Alice"], [2, "Bob"]])
+cur.execute("UPDATE users SET name=? WHERE id=?", ["Alice Cooper", 1])
+cur.execute("DELETE FROM users WHERE id=?", [2])
+cur.execute("ALTER TABLE users ADD COLUMN email TEXT")
+cur.execute("UPDATE users SET email=? WHERE id=?", ["alice@example.com", 1])
+cur.execute("ALTER TABLE users DROP COLUMN email")
+cur.execute("DROP TABLE IF EXISTS temp_users_archive")
+cur.execute("SELECT id, name FROM users ORDER BY id")
+print("Store Device rows:", cur.fetchall())
+cur.execute("close database sample_store_sqlite_py.db")
+cur.close()
+conn.close()

--- a/logger/samples/python/JayDeBeApi/SyncLiteStoreDeviceApp.py
+++ b/logger/samples/python/JayDeBeApi/SyncLiteStoreDeviceApp.py
@@ -1,3 +1,16 @@
+# Copyright (c) 2024 mahendra.chavan@synclite.io, all rights reserved.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied.  See the License for the specific language governing permissions and limitations
+# under the License.
+#
 """
 Store device sample (JayDeBeApi + JDBC URL).
 

--- a/logger/samples/python/JayDeBeApi/SyncLiteStreamingApp.py
+++ b/logger/samples/python/JayDeBeApi/SyncLiteStreamingApp.py
@@ -1,3 +1,16 @@
+# Copyright (c) 2024 mahendra.chavan@synclite.io, all rights reserved.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied.  See the License for the specific language governing permissions and limitations
+# under the License.
+#
 """
 Streaming device sample (JayDeBeApi + JDBC URL).
 

--- a/logger/samples/python/JayDeBeApi/SyncLiteStreamingApp.py
+++ b/logger/samples/python/JayDeBeApi/SyncLiteStreamingApp.py
@@ -1,0 +1,53 @@
+"""
+Streaming device sample (JayDeBeApi + JDBC URL).
+
+Streaming devices are for append-first event capture. The normal pattern is to
+define the stream shape and keep inserting new records that represent events,
+messages, or telemetry.
+
+This is not a mutable relational surface. INSERT is the primary data path,
+selected DDL is supported for schema evolution, and UPDATE or DELETE are shown
+as expected failures.
+"""
+
+import time
+import jaydebeapi
+
+props = {
+    "config": "synclite_logger.conf",
+    "device-name": "streaming-sample"
+}
+
+conn = jaydebeapi.connect(
+    "io.synclite.logger.Streaming",
+    "jdbc:synclite_streaming:sample_streaming_py.db",
+    props,
+    "synclite-logger-<version>.jar"
+)
+
+cur = conn.cursor()
+cur.execute("CREATE TABLE IF NOT EXISTS events(ts BIGINT, event_type TEXT, user_id TEXT)")
+cur.execute("CREATE TABLE IF NOT EXISTS temp_events_archive(id INT, note TEXT)")
+cur.executemany(
+    "INSERT INTO events VALUES(?, ?, ?)",
+    [[int(time.time() * 1000), "CLICK", "user-1"], [int(time.time() * 1000), "VIEW", "user-2"]]
+)
+cur.execute("ALTER TABLE events ADD COLUMN source TEXT")
+cur.execute("INSERT INTO events VALUES(?, ?, ?, ?)", [int(time.time() * 1000), "PURCHASE", "user-3", "mobile"])
+cur.execute("ALTER TABLE events DROP COLUMN source")
+cur.execute("DROP TABLE IF EXISTS temp_events_archive")
+
+# Streaming is append-only from a DML perspective; UPDATE/DELETE should fail.
+try:
+    cur.execute("UPDATE events SET event_type='X' WHERE user_id='user-1'")
+except Exception as e:
+    print("Expected UPDATE failure on Streaming device:", e)
+
+try:
+    cur.execute("DELETE FROM events WHERE user_id='user-2'")
+except Exception as e:
+    print("Expected DELETE failure on Streaming device:", e)
+
+cur.execute("close database sample_streaming_py.db")
+cur.close()
+conn.close()

--- a/logger/samples/python/JayDeBeApi/SyncliteDeviceApp.py
+++ b/logger/samples/python/JayDeBeApi/SyncliteDeviceApp.py
@@ -1,3 +1,16 @@
+# Copyright (c) 2024 mahendra.chavan@synclite.io, all rights reserved.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied.  See the License for the specific language governing permissions and limitations
+# under the License.
+#
 """
 SQL device sample (JayDeBeApi + JDBC URL).
 

--- a/logger/samples/python/JayDeBeApi/SyncliteDeviceApp.py
+++ b/logger/samples/python/JayDeBeApi/SyncliteDeviceApp.py
@@ -1,0 +1,56 @@
+"""
+SQL device sample (JayDeBeApi + JDBC URL).
+
+A SQL device accepts general SQL and logs the statements as written. During
+consolidation those statements are replayed on a replica, CDC is derived from
+the replica, and that change stream is then applied to downstream destinations.
+
+That is why SQL devices can support statements such as INSERT INTO ... SELECT
+... FROM .... Store devices are narrower: they focus on operations where the
+changed data is already explicit in the request so it can be propagated
+directly.
+"""
+
+import jaydebeapi
+
+# SQL-device default: SQLite.
+# Replace for other SQL-device engines:
+# 1) Driver class: io.synclite.logger.SQLite -> Derby, DuckDB, H2, HyperSQL
+# 2) JDBC URL prefix:
+#    jdbc:synclite_sqlite: -> jdbc:synclite_derby:, jdbc:synclite_duckdb:, jdbc:synclite_h2:, jdbc:synclite_hsqldb:
+
+props = {
+    "config": "synclite_logger.conf",
+    "device-name": "txn-sample"
+}
+
+conn = jaydebeapi.connect(
+    "io.synclite.logger.SQLite",
+    "jdbc:synclite_sqlite:sample_txn_sqlite_py.db",
+    props,
+    "synclite-logger-<version>.jar"
+)
+
+cur = conn.cursor()
+cur.execute("CREATE TABLE IF NOT EXISTS feedback(rating INT, comment TEXT)")
+cur.execute("CREATE TABLE IF NOT EXISTS temp_feedback_archive(id INT, note TEXT)")
+cur.execute("INSERT INTO feedback VALUES(3, 'Good product')")
+
+# SQL device supports transactional semantics (commit/rollback).
+conn.jconn.setAutoCommit(False)
+cur.execute("UPDATE feedback SET comment='Better product' WHERE rating=3")
+cur.execute("INSERT INTO feedback VALUES(1, 'Poor product')")
+cur.execute("DELETE FROM feedback WHERE rating=1")
+conn.commit()
+conn.jconn.setAutoCommit(True)
+
+cur.executemany("INSERT INTO feedback VALUES(?, ?)", [[4, "Excellent Product"], [5, "Outstanding Product"]])
+
+cur.execute("ALTER TABLE feedback ADD COLUMN source TEXT")
+cur.execute("UPDATE feedback SET source='web' WHERE rating=3")
+cur.execute("ALTER TABLE feedback DROP COLUMN source")
+cur.execute("DROP TABLE IF EXISTS temp_feedback_archive")
+
+cur.execute("close database sample_txn_sqlite_py.db")
+cur.close()
+conn.close()

--- a/logger/samples/python/README.md
+++ b/logger/samples/python/README.md
@@ -1,0 +1,38 @@
+# Python Samples
+
+This directory contains two bridge-specific sample sets:
+
+- `JayDeBeApi/`: SQL-first Python samples using JayDeBeApi + JDBC.
+- `JPype/`: direct Java API samples using JPype.
+
+## JayDeBeApi
+
+Install dependency:
+
+pip install JayDeBeApi
+
+Run any sample (example):
+
+python JayDeBeApi/SyncliteDeviceApp.py
+
+## JPype
+
+Install dependency:
+
+pip install jpype1
+
+Run any sample (example):
+
+python JPype/SyncLiteStoreAPIApp.py
+
+JPype API-style samples include:
+
+- SyncLiteStoreAPIApp.py
+- SyncLiteStreamAPIApp.py
+- SyncLiteKafkaProduceAPIApp.py
+- SyncLiteJedisAPIApp.py
+
+Notes:
+- Samples default to SQLite and include inline comments for replacing SQL-device/appender device types.
+- Replace synclite-logger-<version>.jar in scripts with your actual jar name/path.
+- Keep synclite_logger.conf in the current working directory.

--- a/logger/src/main/java/io/synclite/logger/Jedis.java
+++ b/logger/src/main/java/io/synclite/logger/Jedis.java
@@ -16,6 +16,7 @@
 
 package io.synclite.logger;
 
+import java.nio.file.Path;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -53,14 +54,20 @@ import redis.clients.jedis.resps.Tuple;
  *
  * <p><strong>Usage:</strong>
  * <pre>
+ *   // Explicit store lifecycle (advanced)
  *   SQLiteStore.initialize(dbPath, configPath);
- *
  *   try (SyncLiteStore store = SQLiteStore.open(dbPath);
  *        Jedis jedis = Jedis.builder(store).host("redis-host").port(6380).build()) {
  *
  *       jedis.set("user:1:name", "Alice");
  *       jedis.hset("session:42", "token", "abc123");
  *       String name = jedis.get("user:1:name");   // reads from Redis
+ *   }
+ *
+ *   // Managed store lifecycle (simple)
+ *   try (Jedis jedis = Jedis.builder(dbPath, configPath, "jedis-device")
+ *           .host("redis-host").port(6380).build()) {
+ *       jedis.set("user:1:name", "Alice");
  *   }
  * </pre>
  *
@@ -93,6 +100,8 @@ public class Jedis extends redis.clients.jedis.Jedis {
     private static final long DEFAULT_PURGE_INTERVAL_SECONDS = 60L;
 
     private final SyncLiteStore store;
+    private final boolean managesStoreLifecycle;
+    private final Path managedStoreDbPath;
     private final ScheduledExecutorService purgeScheduler;
 
     // -------------------------------------------------------------------------
@@ -106,6 +115,27 @@ public class Jedis extends redis.clients.jedis.Jedis {
      */
     public static Builder builder(SyncLiteStore store) {
         return new Builder().store(store);
+    }
+
+    /**
+     * Returns a new {@link Builder} that manages a SQLiteStore lifecycle internally.
+     *
+     * <p>On {@link Builder#build()}, this path will call:
+     * <pre>
+     *   SQLiteStore.initialize(storeDbPath, configPath)
+     *   SQLiteStore.open(storeDbPath)
+     * </pre>
+     * and on {@link #close()} it will close the opened store and device.
+     */
+    public static Builder builder(Path storeDbPath, Path configPath) {
+        return new Builder().sqliteStore(storeDbPath, configPath);
+    }
+
+    /**
+     * Same as {@link #builder(Path, Path)} with explicit SyncLite device name.
+     */
+    public static Builder builder(Path storeDbPath, Path configPath, String deviceName) {
+        return new Builder().sqliteStore(storeDbPath, configPath, deviceName);
     }
 
     /**
@@ -133,11 +163,44 @@ public class Jedis extends redis.clients.jedis.Jedis {
         private int      port          = 6379;
         private long     purgeInterval = DEFAULT_PURGE_INTERVAL_SECONDS;
         private TimeUnit purgeUnit     = TimeUnit.SECONDS;
+        private boolean  manageStoreLifecycle;
+        private Path     managedStoreDbPath;
+        private Path     managedStoreConfigPath;
+        private String   managedStoreDeviceName;
 
         private Builder() {}
 
         public Builder store(SyncLiteStore store) {
             this.store = store;
+            this.manageStoreLifecycle = false;
+            this.managedStoreDbPath = null;
+            this.managedStoreConfigPath = null;
+            this.managedStoreDeviceName = null;
+            return this;
+        }
+
+        /**
+         * Configures this builder to initialize/open SQLiteStore internally.
+         */
+        public Builder sqliteStore(Path dbPath, Path configPath) {
+            this.store = null;
+            this.manageStoreLifecycle = true;
+            this.managedStoreDbPath = dbPath;
+            this.managedStoreConfigPath = configPath;
+            this.managedStoreDeviceName = null;
+            return this;
+        }
+
+        /**
+         * Configures this builder to initialize/open SQLiteStore internally
+         * with a custom SyncLite device name.
+         */
+        public Builder sqliteStore(Path dbPath, Path configPath, String deviceName) {
+            this.store = null;
+            this.manageStoreLifecycle = true;
+            this.managedStoreDbPath = dbPath;
+            this.managedStoreConfigPath = configPath;
+            this.managedStoreDeviceName = deviceName;
             return this;
         }
 
@@ -159,10 +222,44 @@ public class Jedis extends redis.clients.jedis.Jedis {
         }
 
         public Jedis build() throws SQLException {
-            if (store == null) {
-                throw new IllegalStateException("SyncLiteStore must be provided via store()");
+            SyncLiteStore resolvedStore = this.store;
+            boolean resolvedManaged = false;
+            Path resolvedDbPath = null;
+
+            if (resolvedStore == null) {
+                if (!manageStoreLifecycle || managedStoreDbPath == null || managedStoreConfigPath == null) {
+                    throw new IllegalStateException("Either provide store(...) or sqliteStore(dbPath, configPath)");
+                }
+
+                if (managedStoreDeviceName != null && !managedStoreDeviceName.isBlank()) {
+                    SQLiteStore.initialize(managedStoreDbPath, managedStoreConfigPath, managedStoreDeviceName);
+                } else {
+                    SQLiteStore.initialize(managedStoreDbPath, managedStoreConfigPath);
+                }
+                resolvedStore = SQLiteStore.open(managedStoreDbPath);
+                resolvedManaged = true;
+                resolvedDbPath = managedStoreDbPath;
             }
-            return new Jedis(this);
+
+            this.store = resolvedStore;
+
+            try {
+                return new Jedis(this, resolvedManaged, resolvedDbPath);
+            } catch (SQLException e) {
+                if (resolvedManaged && resolvedStore != null) {
+                    try {
+                        resolvedStore.close();
+                    } catch (SQLException ignored) {
+                    }
+                    if (resolvedDbPath != null) {
+                        try {
+                            SQLiteStore.closeDevice(resolvedDbPath);
+                        } catch (SQLException ignored) {
+                        }
+                    }
+                }
+                throw e;
+            }
         }
     }
 
@@ -170,9 +267,11 @@ public class Jedis extends redis.clients.jedis.Jedis {
     // Constructor (private — use Builder)
     // -------------------------------------------------------------------------
 
-    private Jedis(Builder b) throws SQLException {
+    private Jedis(Builder b, boolean managesStoreLifecycle, Path managedStoreDbPath) throws SQLException {
         super(b.host, b.port);
         this.store = b.store;
+        this.managesStoreLifecycle = managesStoreLifecycle;
+        this.managedStoreDbPath = managedStoreDbPath;
         this.purgeScheduler = Executors.newSingleThreadScheduledExecutor(r -> {
             Thread t = new Thread(r, "jedis-purge");
             t.setDaemon(true);
@@ -1314,12 +1413,37 @@ public class Jedis extends redis.clients.jedis.Jedis {
 
     /**
      * Closes the Redis connection and shuts down the background purge scheduler.
-     * The {@link SyncLiteStore} is <em>not</em> closed — its lifecycle is managed by the caller.
+     * The {@link SyncLiteStore} is closed only when this instance created it via
+     * managed builder methods.
      */
     @Override
     public void close() {
         purgeScheduler.shutdownNow();
-        super.close();
+        SQLException storeCloseError = null;
+        try {
+            if (managesStoreLifecycle) {
+                try {
+                    store.close();
+                } catch (SQLException e) {
+                    storeCloseError = e;
+                }
+                if (managedStoreDbPath != null) {
+                    try {
+                        SQLiteStore.closeDevice(managedStoreDbPath);
+                    } catch (SQLException e) {
+                        if (storeCloseError == null) {
+                            storeCloseError = e;
+                        }
+                    }
+                }
+            }
+        } finally {
+            super.close();
+        }
+
+        if (storeCloseError != null) {
+            throw new JedisException("Failed closing managed SyncLiteStore", storeCloseError);
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/logger/src/test/java/io/synclite/logger/JedisTest.java
+++ b/logger/src/test/java/io/synclite/logger/JedisTest.java
@@ -592,6 +592,63 @@ class JedisTest {
         }
     }
 
+    @Test
+    void testManagedBuilderAutoInitializesStoreLifecycle() throws Exception {
+        Path testHome = Path.of(System.getProperty("user.home")).resolve("synclite").resolve("test");
+        Path testDbPath = testHome.resolve("db").resolve("JedisManagedBuilderTest").resolve("test.db");
+        Path testStageDir = testHome.resolve("stageDir");
+
+        for (int attempt = 0; attempt < 20 && Files.exists(testDbPath.getParent()); attempt++) {
+            try { deleteRecursively(testDbPath.getParent()); break; }
+            catch (IOException e) { Thread.sleep(200); }
+        }
+        if (Files.exists(testStageDir)) {
+            try (var dirs = Files.list(testStageDir)) {
+                dirs.filter(p -> p.getFileName().toString().startsWith("synclite-jedismanaged-"))
+                    .forEach(p -> { try { deleteRecursively(p); } catch (IOException ignored) {} });
+            }
+        }
+
+        Files.createDirectories(testDbPath.getParent());
+        Files.createDirectories(testStageDir);
+
+        Path configPath = testDbPath.getParent().resolve("synclite_logger.conf");
+        Files.writeString(configPath,
+                "local-data-stage-directory = " + testStageDir + "\n" +
+                "destination-type = FS\n");
+
+        try (Jedis jedis = Jedis.builder(testDbPath, configPath, "jedismanaged")
+                .host(redisHost)
+                .port(redisPort)
+                .build()) {
+            jedis.set("managed:k1", "v1");
+            assertEquals("v1", jedis.get("managed:k1"));
+        }
+
+        // Store/device lifecycle is managed by Jedis; data should still be durable.
+        try (SyncLiteStore store = SQLiteStore.open(testDbPath)) {
+            List<Map<String, Object>> rows = store.select(Jedis.STRINGS_TABLE, Map.of("key", "managed:k1"));
+            assertEquals(1, rows.size());
+            assertEquals("v1", rows.get(0).get("value"));
+        }
+
+        // Validate warm-up from store using managed builder only (no explicit initialize/open).
+        try (redis.clients.jedis.Jedis raw = new redis.clients.jedis.Jedis(redisHost, redisPort)) {
+            raw.del("managed:k1");
+            assertNull(raw.get("managed:k1"));
+        }
+
+        try (Jedis jedis = Jedis.builder(testDbPath, configPath, "jedismanaged")
+                .host(redisHost)
+                .port(redisPort)
+                .build()) {
+            assertEquals("v1", jedis.get("managed:k1"));
+        }
+
+        SQLiteStore.closeAllDevices();
+        Thread.sleep(150);
+    }
+
     // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR refreshes the sample catalog for `synclite-logger-java`, aligns Java and Python sample coverage, and improves `Jedis` ergonomics by adding a managed SQLiteStore lifecycle builder mode.

It also rewrites sample documentation to clearly explain the behavioral difference between SQL devices and Store devices:

- SQL devices can accept general SQL, log statements as-is, replay on a replica during consolidation, and derive CDC from that replay before applying to destinations.
- Store devices are intentionally narrower and focus on operations where changed data is explicit in the request, so changes can be applied directly downstream.
- Practical differentiator called out in docs: `INSERT INTO ... SELECT ...` is naturally a SQL-device pattern, not the core Store-device model.

---

## Why

The previous sample set and docs were inconsistent with the desired canonical structure and did not clearly communicate the SQL-device vs Store-device replication model.

This PR makes the samples easier to consume, better aligned across Java/Python bridges, and clearer about when to use each device/API surface.

---

## What Changed

### 1) Canonical sample set and layout

- Added/organized canonical Java samples under `logger/samples/java`.
- Split Python samples into bridge-specific folders under `logger/samples/python`:
  - `JayDeBeApi` for SQL/JDBC-oriented Python usage
  - `JPype` for direct Java API usage from Python
- Added sample index/readme files:
  - `logger/samples/README.md`
  - `logger/samples/java/README.md`
  - `logger/samples/python/README.md`
  - `logger/samples/python/JayDeBeApi/README.md`
  - `logger/samples/python/JPype/README.md`
- Updated root `README.md` to point users to local samples.

### 2) Sample behavior parity and clarity

Expanded relevant samples to demonstrate fuller end-to-end operations:

- SQL/Store-oriented samples now demonstrate create/insert/update/delete/schema evolution/drop-table patterns where applicable.
- Streaming samples explicitly demonstrate append + schema evolution flows and expected UPDATE/DELETE failures.
- Java and Python samples were aligned for equivalent intent where each bridge/API supports it.
- Added a JPype Jedis API sample with broader command coverage (strings/hashes/lists/sets/zsets/TTL lifecycle) to match the richer Java Jedis sample intent.

### 3) Jedis managed lifecycle support

Enhanced `Jedis` with managed-store builder overloads:

- `Jedis.builder(Path storeDbPath, Path configPath)`
- `Jedis.builder(Path storeDbPath, Path configPath, String deviceName)`

Behavior:

- In managed mode, `build()` performs SQLiteStore initialize/open internally.
- `Jedis.close()` closes the managed store/device lifecycle.
- Existing explicit-store mode (`builder(SyncLiteStore)`) remains available.

### 4) Jedis tests adapted

- Added `testManagedBuilderAutoInitializesStoreLifecycle()` in `logger/src/test/java/io/synclite/logger/JedisTest.java`.
- Test validates:
  - Managed builder can initialize/open and persist values.
  - Data durability in underlying store.
  - Redis warm-up restoration path using managed builder only.

### 5) Documentation style refresh in samples

- Replaced short label-style doc headers with descriptive, scenario-oriented explanations.
- Clarified SQL-device vs Store-device semantics in both Java and Python sample docs.

---

## Key Files

### Core code

- `logger/src/main/java/io/synclite/logger/Jedis.java`

### Tests

- `logger/src/test/java/io/synclite/logger/JedisTest.java`

### Sample indexes/docs

- `README.md`
- `logger/samples/README.md`
- `logger/samples/java/README.md`
- `logger/samples/python/README.md`
- `logger/samples/python/JayDeBeApi/README.md`
- `logger/samples/python/JPype/README.md`

### Sample apps

- Java canonical sample set in `logger/samples/java/`
- Python JayDeBeApi sample set in `logger/samples/python/JayDeBeApi/`
- Python JPype sample set in `logger/samples/python/JPype/`

---

## Validation

Completed:

- Static validation after sample/doc updates reported no editor errors in:
  - `logger/samples/java`
  - `logger/samples/python`
- Confirmed old label-style markers were removed from sample doc headers.

Not fully completed in this branch session:

- Full Java test run was attempted earlier but cancelled before completion.
- Python sample runtime smoke tests were not executed end-to-end in this session.

---

## Backward Compatibility / Risk

- Low-to-medium risk for runtime behavior:
  - `Jedis` gains new managed lifecycle path but keeps existing explicit-store builder usage.
  - Added close-time lifecycle handling only for managed mode.
- Low risk for sample/docs changes:
  - Most changes are sample additions, organization, and explanatory documentation.

---