### PR TITLE
Strip vestigial `database_id` and `allow_concurrent_writers'

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,138 @@ SyncLite devices fall into three primary categories. Wherever the docs talk abou
 
 - **Streaming Device** — The `STREAMING` device models append-only ingestion with `SyncLiteStream` semantics (fluent `insert` / `insertBatch`). It is optimized for high-throughput event capture and does not support UPDATE/DELETE semantics.
 
+> **Which device should I pick?** Store devices (`*_STORE`) and the `STREAMING` device emit pre-formed row events that the consolidator applies directly to the destination — no SQL-log parsing or CDC-deduction step on the apply path, so they deliver the highest end-to-end consolidation throughput. Reach for a SQL device (`SQLITE`, `DUCKDB`, `DERBY`, `H2`, `HYPERSQL`) when your app actually needs raw SQL, JOINs, multi-statement transactions in one connection, or ad-hoc DDL beyond the schema-evolution the Store API handles for you. For a brand-new app, `SQLITE_STORE` is usually the fastest *and* simplest starting point.
+
 Note: internal device types such as Appender and DBLogger remain implementation details and are intentionally omitted from user-facing documentation.
+
+## Prerequisites
+
+> **Architecture support.** SyncLite is **64-bit only** — `x86_64` and `aarch64` on Windows / Linux / macOS. 32-bit hosts are not supported because the embedded Rust runtime depends on the DuckDB engine, which requires a 64-bit host. This applies whether you build with the Rust runtime bundled (default) or as a logger-only jar (`-DskipRustRuntime=true`) — the Java logger itself targets 64-bit JVMs.
+
+| Tool | Version | When you need it |
+|---|---|---|
+| **JDK** | 25 | Always. The project standardizes on OpenJDK 25 (the `bin/deploy.sh` / `bin/deploy.bat` scripts download it automatically for platform installs). The jar itself is compiled with `--release=11` for broad runtime compatibility, but the build requires JDK 25. |
+| **Maven** | 3.6 or newer (3.8.6+ recommended; tested with 3.9.x) | Building from source. |
+| **Rust toolchain** (`cargo`) | stable (pinned via [synclite-logger-rust/rust-toolchain.toml](../synclite-logger-rust/rust-toolchain.toml)) | Only for the default build that bundles the in-process consolidator native. Skip with `-DskipRustRuntime=true`. |
+| [`cargo-zigbuild`](https://github.com/rust-cross/cargo-zigbuild) + [Zig](https://ziglang.org/download/) | latest stable | **Not needed for this module on its own.** Only required when building from the SyncLite repo root and you want the cross-compiled Linux `x86_64` / `aarch64` `.so` cdylibs bundled into the jar alongside the host-arch native. The standalone `mvn install` here only builds the host-arch cdylib via `cargo build` — no zig involved. |
+| **DuckDB JDBC driver** | 1.5.2.0 | Only if your app uses any DuckDB device. Add as a separate dependency in your app pom; not bundled. |
+
+> On a host without `cargo`, the build still tolerates a missing Rust toolchain — the cargo step and the native-bundling step are best-effort. Passing `-DskipRustRuntime=true` makes the skip explicit and silences the failure log.
+>
+> To install Rust + zig for a full multi-arch build from the repo root:
+>
+> ```bash
+> # Rust (https://rustup.rs/)
+> curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+>
+> # cargo-zigbuild + zig (only for repo-root multi-arch Linux builds)
+> cargo install cargo-zigbuild
+> # zig must be on PATH — download from https://ziglang.org/download/
+> ```
+
+## Build
+
+A single Maven module (`logger/`) produces a single artifact: `synclite-<version>.jar`. The same jar covers both deployment modes — when a Rust toolchain is present the build also bundles the in-process consolidator native (`synclite_jni`); when it isn't, the jar still builds cleanly and contains only the Java logger.
+
+### With the Rust runtime (default)
+
+Requires `cargo` on `PATH`. The pom invokes `cargo build -p synclite-bindings-java --release` against [synclite-logger-rust/](../synclite-logger-rust/) and bundles the resulting `synclite_jni` cdylib into the jar at `META-INF/native/<os-arch>/libsynclite_<rev>_jni.<ext>`.
+
+```bash
+cd synclite-logger-java/logger
+mvn -Drevision=oss clean install
+```
+
+Output: `logger/target/synclite-oss.jar`. The same jar runs in either mode at runtime — the embedded native is used when an in-process consolidator is configured, otherwise the pure-Java logger + shipper path runs.
+
+### Without the Rust runtime (logger-only)
+
+Pass `-DskipRustRuntime=true` if you don't have a Rust toolchain (or just want a faster build). The cargo step and the native-bundling step are skipped; the jar contains only the Java logger.
+
+```bash
+cd synclite-logger-java/logger
+mvn -Drevision=oss -DskipRustRuntime=true clean install
+```
+
+The `*TestWithConsolidator` JUnit suites are auto-skipped under this flag (they need the in-process native).
+
+### Pre-building the Rust native explicitly
+
+For cross-compiled Linux / macOS targets, build the cdylib yourself first; the antrun step will pick up whatever's already in `synclite-logger-rust/target/`:
+
+```bash
+cd synclite-logger-rust
+cargo build -p synclite-bindings-java --release
+# optionally for other targets:
+cargo build -p synclite-bindings-java --release --target <triple>
+
+cd ../synclite-logger-java/logger
+mvn -Drevision=oss clean install
+```
+
+### Skipping tests
+
+Append `-DskipTests` to skip running JUnit, or `-Dmaven.test.skip=true` to skip test compilation too:
+
+```bash
+mvn -Drevision=oss -DskipTests clean install
+mvn -Drevision=oss -Dmaven.test.skip=true clean install
+```
+
+### Build accelerators
+
+None of these are required — they only speed up local iteration and CI.
+
+- **Parallel reactor build** — Maven happily builds the logger module in parallel with its sibling modules when invoked from the repo root:
+
+  ```bash
+  # 1 thread per CPU core
+  mvn -T 1C -Drevision=oss -DskipTests clean install
+  ```
+
+  Inside the single `logger/` module the speed-up is small (it's one module), but the flag is harmless and useful when you're building the full reactor.
+
+- **Skip the Rust native** — the cargo + antrun steps dominate a clean build. Pass `-DskipRustRuntime=true` for the fastest possible logger-only jar (see [Without the Rust runtime](#without-the-rust-runtime-logger-only) above).
+
+- **Skip tests** — `-DskipTests` (run no tests) or `-Dmaven.test.skip=true` (don't even compile them).
+
+- **Offline mode** — once `~/.m2` is warm, `-o` (or `--offline`) avoids Central round-trips on every plugin / dependency lookup.
+
+- **Incremental compilation** — enabled by default in `maven-compiler-plugin` 3.x; nothing to do.
+
+- **[Maven Daemon (`mvnd`)](https://github.com/apache/maven-mvnd)** — long-running JVM, parallel reactor by default, typically 2–3× faster than vanilla `mvn` on warm caches:
+
+  ```bash
+  mvnd -Drevision=oss -DskipTests clean install
+  ```
+
+- **Rust-side `sccache`** — the Rust native build dominates clean builds. Wire up [sccache](https://github.com/mozilla/sccache) on the host (it's transparent to Maven):
+
+  ```bash
+  cargo install sccache
+  export RUSTC_WRAPPER=sccache            # bash / zsh
+  $env:RUSTC_WRAPPER = "sccache"          # PowerShell
+  ```
+
+- **Pre-built Rust cdylib** — if you build the Rust workspace yourself first (see [Pre-building the Rust native explicitly](#pre-building-the-rust-native-explicitly) above), then run `mvn -Drevision=oss -DskipRustRuntime=true clean install`, the antrun bundling step still picks up whatever's already in `synclite-logger-rust/target/release/`. This lets you cache the Rust artifacts independently in CI.
+
+- **`MAVEN_OPTS` heap tuning** — for the full reactor on a fat box, give Maven more heap to avoid GC churn:
+
+  ```bash
+  export MAVEN_OPTS="-Xmx4g"
+  ```
+
+### Building from the repo root (full reactor)
+
+The repo-root build adds one flag on top of everything above: **`-DskipRustCrossCompile=true`** skips the two Linux cross-compile cargo runs (`x86_64-unknown-linux-gnu` + `aarch64-unknown-linux-gnu`) so you don't need `cargo-zigbuild` + `zig` on `PATH`. The host-arch cdylib is still built and bundled. The flag is root-pom only — inside this module use `-DskipRustRuntime=true` instead.
+
+```bash
+# Fastest reactor build on a host without zig — host-arch cdylib only.
+mvn -Drevision=oss -DskipRustCrossCompile=true -DskipTests clean install
+```
+
+For the full platform / runtime zips, see the [top-level build instructions](../README.md#building-from-source) in the SyncLite repo root.
+
 ## Quick Start
 
 ### End-to-end PostgreSQL sample (30 seconds)
@@ -197,19 +328,20 @@ Or copy `synclite-<version>.jar` from the platform release into your project cla
 > avoid native-library version mismatches. Non-DuckDB users can ignore
 > this dependency entirely.
 
-DuckDB users must add `org.duckdb:duckdb_jdbc:1.5.2.0` themselves.
+The **central Consolidator** that drains staged segments into your destination is a separate component — a Tomcat WAR deployed from the platform release, not a Maven dependency. See [SyncLite Consolidator](../synclite-consolidator/) for setup.
 
 ### 2. Configure `synclite.conf`
 
-A full sample config file is provided at `logger/src/main/resources/synclite.conf`. At minimum, set:
+`synclite.conf` is **optional**. With no config file at all, SyncLite uses sensible defaults out of the box — segments and consolidator work go under `<user-home>/synclite/job1/` (`stageDir/` for staged segments, `workDir/` for consolidator state). The device type comes from which class you call `initialize` on (`SQLite`, `DuckDB`, `Streaming`, …) — no `device-type=` key needed.
+
+A full sample config covering every tunable lives at [`logger/src/main/resources/synclite.conf`](logger/src/main/resources/synclite.conf). Drop in a file only when you need to override a default — for example, a custom stage path:
 
 ```properties
-# Where to write the local sync logs (staging directory)
-local-data-stage-directory=<path/to/stage>
-
-# Where the final destination is (can also be configured in Consolidator UI)
-device-stage-type=SQLITE
+# Optional — override the default <user-home>/synclite/job1/stageDir
+local-data-stage-directory=/var/lib/myapp/synclite-stage
 ```
+
+Destination wiring (`dst-type-1`, `dst-connection-string-1`, mappers, sync mode, Prometheus, etc.) goes in the same file when you're using the in-process consolidator. See the sample for the full key reference.
 
 ### 3. Initialize and use in Java
 
@@ -377,7 +509,7 @@ The `Jedis.builder(SyncLiteStore)` overload is available when the application ma
 
 ## Non-Java Runtimes
 
-The Java SDK is JVM-only. For **Python, C/C++, Go, Ruby, Node.js, Rust** — anything that can call a C ABI — use the [SyncLite Rust runtime](../synclite-logger-rust/) which packages the same logger + embedded consolidator behind a C ABI plus PyO3 bindings. Python samples live in [`synclite-code-samples/synclite-logger/python/`](../synclite-code-samples/synclite-logger/python/).
+The Java SDK is JVM-only. For **Python, C/C++, Go, Ruby, Node.js, Rust** — anything that can call a C ABI — use the [SyncLite Rust runtime](../synclite-logger-rust/) which packages the same logger + embedded consolidator behind a stable C ABI. Python users get a dependency-free ctypes wrapper today (`lib/python/synclite.py`) and the richer `synclite-logger-python` PyO3 wheel is on the roadmap. Python samples live in [`synclite-code-samples/synclite-runtime/python/`](../synclite-code-samples/synclite-runtime/python/).
 
 ## Code Samples
 
@@ -395,7 +527,7 @@ samples/
 └─ SyncLiteKafkaProduceApp.java    # Kafka-style producer facade
 ```
 
-Python samples live under [`synclite-code-samples/synclite-logger/python/`](../synclite-code-samples/synclite-logger/python/).
+Python samples live under [`synclite-code-samples/synclite-runtime/python/`](../synclite-code-samples/synclite-runtime/python/).
 
 ## Staging Storages Supported
 
@@ -409,52 +541,6 @@ Python samples live under [`synclite-code-samples/synclite-logger/python/`](../s
 | Microsoft OneDrive | Enterprise cloud share |
 | Google Drive | Personal/workspace cloud share |
 | NFS / Network share | LAN-level sharing |
-
-## Build
-
-A single Maven module (`logger/`) produces a single artifact: `synclite-<version>.jar`. The same jar covers both deployment modes — when a Rust toolchain is present the build also bundles the in-process consolidator native (`synclite_jni`); when it isn't, the jar still builds cleanly and contains only the Java logger.
-
-```bash
-cd synclite-logger-java/logger
-mvn -Drevision=oss clean install
-```
-
-Output: `logger/target/synclite-oss.jar`.
-
-### Skipping the Rust build
-
-If you don't have a Rust toolchain (or only need the logger-only jar), pass `-DskipRustRuntime=true`:
-
-```bash
-mvn -Drevision=oss -DskipRustRuntime=true clean install
-```
-
-Without this flag the build still tolerates a missing `cargo` — the cargo step and the native-bundling antrun step are both best-effort (`failOnError=false`). The flag just makes the skip explicit and silences the failure log.
-
-### Building the Rust native explicitly
-
-The pom invokes `cargo build -p synclite-bindings-java --release` against [synclite-logger-rust/](../synclite-logger-rust/) automatically. To pre-build (e.g. cross-compiled Linux/macOS targets), run it yourself first — the antrun step will pick up whatever's already in `synclite-logger-rust/target/`:
-
-```bash
-cd synclite-logger-rust
-cargo build -p synclite-bindings-java --release
-# optionally for other targets:
-cargo build -p synclite-bindings-java --release --target <triple>
-
-cd ../synclite-logger-java/logger
-mvn -Drevision=oss clean install
-```
-
-The native ends up at `META-INF/native/<os-arch>/libsynclite_<rev>_jni.<ext>` inside the jar; `NativeLoader` resolves it at runtime from the classpath.
-
-### Skipping tests
-
-Append `-DskipTests` to skip running JUnit, or `-Dmaven.test.skip=true` to skip test compilation too:
-
-```bash
-mvn -Drevision=oss -DskipTests clean install
-mvn -Drevision=oss -Dmaven.test.skip=true clean install
-```
 
 ## Related Components
 

--- a/logger/src/main/java/io/synclite/LogCleaner.java
+++ b/logger/src/main/java/io/synclite/LogCleaner.java
@@ -30,7 +30,6 @@ import org.apache.log4j.Logger;
 public class LogCleaner {
 
 	private final Path dbPath;
-	private final long databaseID;
 	private final List<LogShipper> logShippers;
 	private final AtomicLong cleanedLogSegmentSequenceNumber = new AtomicLong(-1);
 	private final AtomicLong cleanedDataFileSequenceNumber = new AtomicLong(-1);
@@ -39,9 +38,8 @@ public class LogCleaner {
 	private final LogSegmentPlacer logSegmentPlacer;
 	private final Logger tracer;
 
-	LogCleaner(Path dbPath, long databaseID, List<LogShipper> logShippers, LogSegmentPlacer logSegmentPlacer, MetadataManager metadataMgr, SyncLiteOptions options, Logger tracer) throws SQLException  {
+	LogCleaner(Path dbPath, List<LogShipper> logShippers, LogSegmentPlacer logSegmentPlacer, MetadataManager metadataMgr, SyncLiteOptions options, Logger tracer) throws SQLException  {
 		this.dbPath = dbPath;
-		this.databaseID = databaseID;
 		this.logShippers = logShippers;
 		this.logSegmentPlacer = logSegmentPlacer;
 		this.metadataMgr = metadataMgr;
@@ -81,7 +79,7 @@ public class LogCleaner {
 
 			boolean cleaned = false;
 			for (long seq = cleanedLogSegmentSequenceNumber.get() + 1; seq <= cleanLogsUpto; ++seq) {
-				Path logFilePath = logSegmentPlacer.getLogSegmentPath(this.dbPath, this.databaseID, seq);
+				Path logFilePath = logSegmentPlacer.getLogSegmentPath(this.dbPath, seq);
 				if (Files.exists(logFilePath)) {
 					Files.delete(logFilePath);
 				}
@@ -110,7 +108,7 @@ public class LogCleaner {
 
 			boolean cleaned = false;
 			for (long seq = cleanedDataFileSequenceNumber.get() + 1; seq <= cleanDataFilesUpto; ++seq) {
-				Path dataFilePath = logSegmentPlacer.getDataFilePath(this.dbPath, this.databaseID, seq);
+				Path dataFilePath = logSegmentPlacer.getDataFilePath(this.dbPath, seq);
 				if (Files.exists(dataFilePath)) {
 					Files.delete(dataFilePath);
 				}

--- a/logger/src/main/java/io/synclite/LogMover.java
+++ b/logger/src/main/java/io/synclite/LogMover.java
@@ -23,9 +23,9 @@ import org.apache.log4j.Logger;
 
 public class LogMover extends LogShipper {
 
-	public LogMover(Path dbPath, long databaseID, String writeArchieveName, LogSegmentPlacer logSegmentPlacer, MetadataManager metadataMgr,
+	public LogMover(Path dbPath, String writeArchieveName, LogSegmentPlacer logSegmentPlacer, MetadataManager metadataMgr,
 			SyncLiteOptions options, Integer destIndex, Logger tracer) throws SQLException {
-		super(dbPath, databaseID, writeArchieveName, logSegmentPlacer, metadataMgr, options, destIndex, tracer);
+		super(dbPath, writeArchieveName, logSegmentPlacer, metadataMgr, options, destIndex, tracer);
 	}
 
 	@Override

--- a/logger/src/main/java/io/synclite/LogSegmentPlacer.java
+++ b/logger/src/main/java/io/synclite/LogSegmentPlacer.java
@@ -20,8 +20,8 @@ import java.nio.file.Path;
 
 public abstract class LogSegmentPlacer {
 
-	protected abstract Path getLogSegmentPath(Path dbPath, long dbID, long seqNum);
-	protected abstract Path getDataFilePath(Path dbPath, long dbID, long seqNum);
+	protected abstract Path getLogSegmentPath(Path dbPath, long seqNum);
+	protected abstract Path getDataFilePath(Path dbPath, long seqNum);
 	protected abstract Path getTxnStageFilePath(Path dbPath, long txnID);
 	protected abstract boolean isTxnFileForLogSegment(long logSeqNum, Path p);
 	

--- a/logger/src/main/java/io/synclite/LogShipper.java
+++ b/logger/src/main/java/io/synclite/LogShipper.java
@@ -33,7 +33,6 @@ class LogShipper {
     protected final ConcurrentHashMap<String, Long> clientCommands = new ConcurrentHashMap<String, Long>();
     protected final Path dbPath;
     protected final Path syncLiteDirPath;
-    protected final long databaseID;
     protected final String writeArchieveName;
     protected final Path writeArchievePath;
     protected final FSArchiver archiver;
@@ -49,11 +48,10 @@ class LogShipper {
     protected final Logger tracer;
     private boolean copyTxnFiles = false;
 
-    LogShipper(Path dbPath, long databaseID, String writeArchieveName, LogSegmentPlacer logSegmentPlacer, MetadataManager metadataMgr, SyncLiteOptions options, Integer destIndex, Logger tracer) throws SQLException {
+    LogShipper(Path dbPath, String writeArchieveName, LogSegmentPlacer logSegmentPlacer, MetadataManager metadataMgr, SyncLiteOptions options, Integer destIndex, Logger tracer) throws SQLException {
     	this.destIndex = destIndex;
         this.dbPath = dbPath;
         this.syncLiteDirPath = Path.of(this.dbPath + ".synclite");
-        this.databaseID = databaseID;
         this.writeArchieveName = writeArchieveName;
         this.metadataMgr = metadataMgr;
         this.writeArchievePath = Path.of(options.getLocalDataStageDirectory(destIndex).toString(), this.writeArchieveName + "/");
@@ -142,7 +140,7 @@ class LogShipper {
             boolean moved = false;
             long shippedUpto = -1;
             for (long i = currentShippedDataFileSequenceNumber + 1; i <= currentDataFileSequenceNumber; ++i) {
-                Path dataFilePath = logSegmentPlacer.getDataFilePath(this.dbPath, this.databaseID, i);
+                Path dataFilePath = logSegmentPlacer.getDataFilePath(this.dbPath, i);
                 doShip(dataFilePath);
                 moved = true;
                 shippedUpto = i;
@@ -154,7 +152,7 @@ class LogShipper {
                 
                 //Cleanup shipped data files
                 for (long i = currentShippedDataFileSequenceNumber + 1; i <= shippedUpto; ++i) {
-                    Path dataFilePath = logSegmentPlacer.getDataFilePath(this.dbPath, this.databaseID, i);
+                    Path dataFilePath = logSegmentPlacer.getDataFilePath(this.dbPath, i);
                 	doClean(dataFilePath);
                 }                
             }
@@ -181,7 +179,7 @@ class LogShipper {
                         }
                 	}
                 }
-            	Path logFilePath = logSegmentPlacer.getLogSegmentPath(this.dbPath, this.databaseID, i);
+            	Path logFilePath = logSegmentPlacer.getLogSegmentPath(this.dbPath, i);
                 doShip(logFilePath);
                 moved = true;
                 shippedUpto = i;
@@ -200,7 +198,7 @@ class LogShipper {
                             }
                         }
                 	}                	
-                	Path logFilePath = logSegmentPlacer.getLogSegmentPath(this.dbPath, this.databaseID, i);
+                	Path logFilePath = logSegmentPlacer.getLogSegmentPath(this.dbPath, i);
                 	doClean(logFilePath);
                 }
             }

--- a/logger/src/main/java/io/synclite/SQLLogger.java
+++ b/logger/src/main/java/io/synclite/SQLLogger.java
@@ -76,7 +76,6 @@ abstract class SQLLogger extends Thread {
 	protected String restartTxnFate;
 	protected String restartLoggedSQL;
 	protected long backupShipped;
-	protected long databaseID;
 	protected long lastProcessedRequestID;
 	protected long lastProcessingRequestID;
 	protected String lastProcessingCommand;
@@ -187,18 +186,18 @@ abstract class SQLLogger extends Thread {
 		//Else we create multiple LogShippers + LogCleaner
 		//
 		if ((options.getNumDestinations() == 1)) {
-			LogMover mover = new LogMover(this.dbPath, this.databaseID, getWriteArchiveName(), logSegmentPlacer, metadataMgr, this.options, 1, this.tracer);
+			LogMover mover = new LogMover(this.dbPath, getWriteArchiveName(), logSegmentPlacer, metadataMgr, this.options, 1, this.tracer);
 			logShippers.add(mover);
 			mover.setLogSegmentSequenceNumber(this.logSegmentSequenceNumber);
 			mover.setDataFileSequenceNumber(this.dataFileSequenceNumber);
 		} else {
 			for (Integer i=1 ; i <= options.getNumDestinations(); ++i) {
-				LogShipper shipper = new LogShipper(this.dbPath, this.databaseID, getWriteArchiveName(), logSegmentPlacer, this.metadataMgr, this.options, i, this.tracer);
+				LogShipper shipper = new LogShipper(this.dbPath, getWriteArchiveName(), logSegmentPlacer, this.metadataMgr, this.options, i, this.tracer);
 				logShippers.add(shipper);
 				shipper.setLogSegmentSequenceNumber(this.logSegmentSequenceNumber);
 				shipper.setDataFileSequenceNumber(this.dataFileSequenceNumber);
 			}
-			logCleaner = new LogCleaner(this.dbPath, this.databaseID, this.logShippers, this.logSegmentPlacer, metadataMgr, this.options, this.tracer);			
+			logCleaner = new LogCleaner(this.dbPath, this.logShippers, this.logSegmentPlacer, metadataMgr, this.options, this.tracer);			
 		}
 	}
 
@@ -351,19 +350,6 @@ abstract class SQLLogger extends Thread {
 			metadataMgr.insertProperty("data_file_sequence_number", this.dataFileSequenceNumber);
 		}
 
-		longVal = metadataMgr.getLongProperty("database_id");
-		if (longVal != null) {
-			this.databaseID = longVal;
-		} else {
-			if (options.getDatabaseId() != -1) {
-				this.databaseID = options.getDatabaseId();
-			} else {
-				this.databaseID = 0;
-			}
-			metadataMgr.insertProperty("database_id", this.databaseID);
-		}
-		options.setDatabaseId(this.databaseID);
-
 		longVal = metadataMgr.getLongProperty("last_processed_request_id");
 		if (longVal != null) {
 			this.lastProcessedRequestID = longVal;
@@ -467,7 +453,7 @@ abstract class SQLLogger extends Thread {
 	}
 
 	private final void initLogSegment(long seqNum) throws SQLException {
-		this.logPath = logSegmentPlacer.getLogSegmentPath(this.dbPath, this.databaseID, seqNum);
+		this.logPath = logSegmentPlacer.getLogSegmentPath(this.dbPath, seqNum);
 		String url = "jdbc:sqlite:" + logPath;
 		logTableConn = DriverManager.getConnection(url);
 		inlinedArgCnt = options.getLogMaxInlinedArgs();
@@ -850,7 +836,7 @@ abstract class SQLLogger extends Thread {
 	final Path logDataFile(Path sourceFilePath) throws SQLException {
 		try {
 			long seqNum = dataFileSequenceNumber.get() + 1;
-			Path dataFile = logSegmentPlacer.getDataFilePath(this.dbPath, this.databaseID, seqNum);
+			Path dataFile = logSegmentPlacer.getDataFilePath(this.dbPath, seqNum);
 			//Copy the supplied sourceFilePath to dataFile		
 			Files.copy(sourceFilePath, dataFile);
 			dataFileSequenceNumber.addAndGet(1L);

--- a/logger/src/main/java/io/synclite/SyncLite.java
+++ b/logger/src/main/java/io/synclite/SyncLite.java
@@ -456,8 +456,6 @@ public class SyncLite extends org.sqlite.JDBC {
 	public static final void reSynchronizeDevice(DeviceType deviceType, Path dbPath) throws SQLException {
 		SyncLiteOptions options = SQLLogger.getSyncLiteOptions(dbPath);
 		SQLLogger.cleanUpDevice(dbPath);
-		//Bump up databaseID
-		options.setDatabaseId(options.getDatabaseId() + 1);
 		initialize(deviceType, dbPath, options);
 	}
 
@@ -507,13 +505,11 @@ public class SyncLite extends org.sqlite.JDBC {
 		return ".txn";
 	}
 
-	static final Path getLogSegmentPath(Path dbPath, long databaseID, long seqNum) {
-		//return Path.of(dbPath.toString() + ".synclite", dbPath.getFileName().toString() + getLogSegmentSignature() + databaseID + "."  + seqNum);
+	static final Path getLogSegmentPath(Path dbPath, long seqNum) {
 		return Path.of(dbPath.toString() + ".synclite", seqNum + getLogSegmentSignature());
 	}
 
-	static final Path getDataFilePath(Path dbPath, long databaseID, long seqNum) {
-		//return Path.of(dbPath.toString() + ".synclite", dbPath.getFileName().toString() + getDataFileSignature() + databaseID + "." +seqNum);
+	static final Path getDataFilePath(Path dbPath, long seqNum) {
 		return Path.of(dbPath.toString() + ".synclite", seqNum + getDataFileSignature());
 	}
 

--- a/logger/src/main/java/io/synclite/SyncLiteOptions.java
+++ b/logger/src/main/java/io/synclite/SyncLiteOptions.java
@@ -57,7 +57,6 @@ public class SyncLiteOptions {
 	private Path encryptionKeyFile = null;
 	private List<String> includeTables = null;
 	private List<String> excludeTables = null;
-	private long databaseId = -1;
 	private String uuid = null;
 	private DeviceType deviceType;
 	private Logger tracer;
@@ -83,7 +82,6 @@ public class SyncLiteOptions {
 		copy.disableAsyncLoggingForTxnDevice = this.disableAsyncLoggingForTxnDevice;
 		copy.enableAsyncLoggingForAppenderDevice = this.enableAsyncLoggingForAppenderDevice;
 		copy.encryptionKeyFile = this.encryptionKeyFile;
-		copy.databaseId = this.databaseId;
 		for (Map.Entry<Integer, DestinationType> entry : this.destTypes.entrySet()) {
 			copy.destTypes.put(entry.getKey(), entry.getValue());
 		}
@@ -268,14 +266,6 @@ public class SyncLiteOptions {
 	
 	public void setExternalCommandHandler(String handler) {
 		this.externalCommandHandler = handler;
-	}
-
-	long getDatabaseId() throws SQLException {
-		return this.databaseId;
-	}
-
-	void setDatabaseId(long deviceDBID) throws SQLException {
-		this.databaseId = deviceDBID;
 	}
 
 	void setUUID(String deviceUUID) throws SQLException {

--- a/logger/src/main/java/io/synclite/TxnLogger.java
+++ b/logger/src/main/java/io/synclite/TxnLogger.java
@@ -88,10 +88,6 @@ abstract class TxnLogger extends SQLLogger {
 		}
 		
 		boolean allowsConcurrentWrites = SyncLiteUtils.deviceAllowsConcurrentWriters(options.getDeviceType());
-		strVal = metadataMgr.getStringProperty("allow_concurrent_writers");
-		if (strVal == null) {
-			metadataMgr.insertProperty("allow_concurrent_writers", allowsConcurrentWrites);
-		}		
 		this.allowsConcurrentWrites = allowsConcurrentWrites;
 	}
 

--- a/logger/src/main/java/io/synclite/TxnLoggerLogSegmentPlacer.java
+++ b/logger/src/main/java/io/synclite/TxnLoggerLogSegmentPlacer.java
@@ -24,13 +24,13 @@ public class TxnLoggerLogSegmentPlacer extends LogSegmentPlacer {
 	}
 
 	@Override
-	protected Path getLogSegmentPath(Path dbPath, long dbID, long seqNum) {
-		return SQLite.getLogSegmentPath(dbPath, dbID, seqNum);
+	protected Path getLogSegmentPath(Path dbPath, long seqNum) {
+		return SQLite.getLogSegmentPath(dbPath, seqNum);
 	}
 
 	@Override
-	protected Path getDataFilePath(Path dbPath, long dbID, long seqNum) {
-		return SQLite.getDataFilePath(dbPath, dbID, seqNum);
+	protected Path getDataFilePath(Path dbPath, long seqNum) {
+		return SQLite.getDataFilePath(dbPath, seqNum);
 	}
 
 	@Override

--- a/logger/src/test/java/io/synclite/ConsolidationTestSupport.java
+++ b/logger/src/test/java/io/synclite/ConsolidationTestSupport.java
@@ -49,7 +49,6 @@ import java.util.stream.Collectors;
  *   ~/synclite/test/javaloggerconsolidator/workDir/
  *       consolidated_db.sqlite                   &lt;-- shared destination
  *       synclite_consolidator_statistics.db
- *       synclite_device_metadata.db
  *       synclite-&lt;device&gt;-&lt;uuid&gt;/             &lt;-- per-device work area
  * </pre>
  *

--- a/samples/README.md
+++ b/samples/README.md
@@ -39,6 +39,9 @@ Notes:
 
 ## Python users
 
-Python does not use this Java logger. Python consumes SyncLite through the
-Rust runtime and its PyO3 bindings (`synclite` package). Samples live in
-[`synclite-code-samples/synclite-logger/python/`](../../synclite-code-samples/synclite-logger/python/).
+Python does not use this Java logger. Python consumes SyncLite through
+the Rust runtime — today via a small ctypes wrapper over the C ABI
+(`lib/python/synclite.py` shipped in every release zip), and soon via
+the upcoming `synclite-logger-python` PyO3 wheel for the richer API.
+Samples live in
+[`synclite-code-samples/synclite-runtime/python/`](../../synclite-code-samples/synclite-runtime/python/).


### PR DESCRIPTION
# Strip vestigial `database_id` and `allow_concurrent_writers`; README restructure

## What this PR changes

### Code: drop two vestigial metadata properties
Two per-device metadata properties no longer participate in cross-stack behavior:

- **`database_id`** (`long databaseID`) — was seeded into per-device metadata and threaded into every log-segment / data-file path builder, with no remaining consumer in the consolidator or the runtime.
- **`allow_concurrent_writers`** — was persisted into per-device metadata, but the consolidator now derives the value directly from `Device.allowsConcurrentWriters()` (default true; false only for `SQLITE` / `SQLITE_STORE`).

The logger keeps its in-process derived flag (`allowsConcurrentWrites`) using `SyncLiteUtils.deviceAllowsConcurrentWriters(options.getDeviceType())`. Only the persisted metadata seed is gone.

### README restructure
- New top-level **`## Prerequisites`** section placed before `## Quick Start`. Covers:
  - **64-bit-only architecture callout** (Windows / Linux / macOS on `x86_64` and `aarch64`; 32-bit is unsupported because the embedded Rust runtime depends on DuckDB).
  - **JDK 25** to build (the jar itself is still compiled with `--release=11` for broad runtime compatibility).
  - **Maven 3.6+** (3.8.6+ recommended; tested with 3.9.x).
  - **Rust toolchain** (`cargo` on `PATH`), pinned to `stable` via the sibling Rust workspace's `rust-toolchain.toml`. Skippable with `-DskipRustRuntime=true`.
  - **`cargo-zigbuild` + Zig** — not required for the standalone logger build; only needed when building the full reactor with multi-arch Linux cdylibs from the SyncLite repo root.
  - **DuckDB JDBC driver** (`org.duckdb:duckdb_jdbc:1.5.2.0`) — not bundled in the SyncLite jar; required only if the app uses any DuckDB device.
- **`## Build`** moved above `## Quick Start` so the standard *Prerequisites → Build → Use* flow reads top-to-bottom. Subsection headings promoted from `####` to `###`.
- New subsections under `## Build`: **With Rust runtime**, **Without Rust runtime** (`-DskipRustRuntime=true`), **Pre-building Rust** (reuse a prebuilt cdylib), **Skipping tests**, **Build accelerators** (parallel reactor `mvn -T 1C`, [Maven Daemon `mvnd`](https://github.com/apache/maven-mvnd), host-side [`sccache`](https://github.com/mozilla/sccache), prebuilt-cdylib pattern for CI, `MAVEN_OPTS=-Xmx4g`), **Building from the repo root** (simplified; documents `-DskipRustCrossCompile=true` for hosts without `cargo-zigbuild` + `zig`).
- **Fat-artifact bug fix.** The README previously claimed `io.synclite:synclite-consolidator` was an embeddable JAR for the in-process consolidator. It is in fact a Tomcat WAR deployed from the platform release. Replaced the incorrect block with a one-liner pointer to the [SyncLite Consolidator](../synclite-consolidator/) module.
- **"Which device should I pick?"** callout added under `## Device Types`: Store devices (`*_STORE`) and `STREAMING` deliver the highest end-to-end consolidation throughput because the consolidator applies their pre-formed row events directly to the destination — no SQL-log parsing or CDC-deduction step. SQL devices (`SQLITE`, `DUCKDB`, `DERBY`, `H2`, `HYPERSQL`) remain the choice when raw SQL, JOINs, multi-statement transactions in one connection, or ad-hoc DDL are required. For brand-new apps, `SQLITE_STORE` is recommended.
- **`### 2. Configure synclite.conf`** rewritten. `synclite.conf` is now documented as **optional** — defaults under `<user-home>/synclite/job1/` work out of the box. Removed the previous example that incorrectly used `device-stage-type=SQLITE` (that key is the staging *transport* — `FS|SFTP|S3|MINIO|...`, default `FS` — not a device class). The device type comes from the class the user calls `initialize` on (`SQLite`, `DuckDB`, ...) so no `device-type=` key is needed for a minimal setup; only the optional `local-data-stage-directory` override is shown.

## Changed files

| File | Change |
| --- | --- |
| `logger/src/main/java/io/synclite/SyncLiteOptions.java` | Drop `databaseId` field, copy line, and `getDatabaseId()` / `setDatabaseId()` accessors. |
| `logger/src/main/java/io/synclite/SQLLogger.java` | Drop `protected long databaseID` field and the entire `database_id` metadata read / seed / write block. Update `LogMover` / `LogShipper` / `LogCleaner` ctor calls. `initLogSegment` and `logDataFile` stop passing `databaseID` into path builders. |
| `logger/src/main/java/io/synclite/SyncLite.java` | `reSynchronizeDevice` no longer bumps `databaseId`. Static `getLogSegmentPath(Path, long)` and `getDataFilePath(Path, long)` signatures simplified. |
| `logger/src/main/java/io/synclite/LogSegmentPlacer.java` | Abstract signature updated to `(Path, long seqNum)`. |
| `logger/src/main/java/io/synclite/TxnLoggerLogSegmentPlacer.java` | Concrete signature updated to `(Path, long seqNum)`. |
| `logger/src/main/java/io/synclite/LogShipper.java` | Remove `databaseID` field + ctor param; simplify all path-builder call sites. |
| `logger/src/main/java/io/synclite/LogMover.java` | Remove `databaseID` field + ctor param; simplify all path-builder call sites. |
| `logger/src/main/java/io/synclite/LogCleaner.java` | Remove `databaseID` field + ctor param; simplify all path-builder call sites. |
| `logger/src/main/java/io/synclite/TxnLogger.java` | Remove `metadataMgr.insertProperty("allow_concurrent_writers", ...)` seed. Keep derived `allowsConcurrentWrites`. |
| `logger/src/test/java/io/synclite/ConsolidationTestSupport.java` | Update test helper signatures (drop `databaseID` plumbing). |
| `README.md` | Restructure to *Prerequisites → Build → Quick Start*; new Build accelerators subsection; "Which device should I pick?" callout; rewritten `synclite.conf` section; fat-artifact fix. |
| `samples/README.md` | Naming + path touch-ups aligned with the `synclite-runtime` rename. |

## Compatibility notes

- Pre-existing per-device metadata stores may still carry the two stripped properties on disk; they are now ignored on read and no longer written. No migration is required.
- Path builders for log segments and data files lost the `databaseID` parameter — any external code linking these static helpers must drop the argument.
