### PR TITLE
Logger hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,10 +127,10 @@ Requires `cargo` on `PATH`. The pom invokes `cargo build -p synclite-bindings-ja
 
 ```bash
 cd synclite-logger-java/logger
-mvn -Drevision=oss clean install
+mvn -Drevision=1.0.0 clean install
 ```
 
-Output: `logger/target/synclite-oss.jar`. The same jar runs in either mode at runtime — the embedded native is used when an in-process consolidator is configured, otherwise the pure-Java logger + shipper path runs.
+Output: `logger/target/synclite-1.0.0.jar`. The same jar runs in either mode at runtime — the embedded native is used when an in-process consolidator is configured, otherwise the pure-Java logger + shipper path runs.
 
 ### Without the Rust runtime (logger-only)
 
@@ -138,7 +138,7 @@ Pass `-DskipRustRuntime=true` if you don't have a Rust toolchain (or just want a
 
 ```bash
 cd synclite-logger-java/logger
-mvn -Drevision=oss -DskipRustRuntime=true clean install
+mvn -Drevision=1.0.0 -DskipRustRuntime=true clean install
 ```
 
 The `*TestWithConsolidator` JUnit suites are auto-skipped under this flag (they need the in-process native).
@@ -154,7 +154,7 @@ cargo build -p synclite-bindings-java --release
 cargo build -p synclite-bindings-java --release --target <triple>
 
 cd ../synclite-logger-java/logger
-mvn -Drevision=oss clean install
+mvn -Drevision=1.0.0 clean install
 ```
 
 ### Skipping tests
@@ -162,8 +162,8 @@ mvn -Drevision=oss clean install
 Append `-DskipTests` to skip running JUnit, or `-Dmaven.test.skip=true` to skip test compilation too:
 
 ```bash
-mvn -Drevision=oss -DskipTests clean install
-mvn -Drevision=oss -Dmaven.test.skip=true clean install
+mvn -Drevision=1.0.0 -DskipTests clean install
+mvn -Drevision=1.0.0 -Dmaven.test.skip=true clean install
 ```
 
 ### Build accelerators
@@ -174,7 +174,7 @@ None of these are required — they only speed up local iteration and CI.
 
   ```bash
   # 1 thread per CPU core
-  mvn -T 1C -Drevision=oss -DskipTests clean install
+  mvn -T 1C -Drevision=1.0.0 -DskipTests clean install
   ```
 
   Inside the single `logger/` module the speed-up is small (it's one module), but the flag is harmless and useful when you're building the full reactor.
@@ -190,7 +190,7 @@ None of these are required — they only speed up local iteration and CI.
 - **[Maven Daemon (`mvnd`)](https://github.com/apache/maven-mvnd)** — long-running JVM, parallel reactor by default, typically 2–3× faster than vanilla `mvn` on warm caches:
 
   ```bash
-  mvnd -Drevision=oss -DskipTests clean install
+  mvnd -Drevision=1.0.0 -DskipTests clean install
   ```
 
 - **Rust-side `sccache`** — the Rust native build dominates clean builds. Wire up [sccache](https://github.com/mozilla/sccache) on the host (it's transparent to Maven):
@@ -201,7 +201,7 @@ None of these are required — they only speed up local iteration and CI.
   $env:RUSTC_WRAPPER = "sccache"          # PowerShell
   ```
 
-- **Pre-built Rust cdylib** — if you build the Rust workspace yourself first (see [Pre-building the Rust native explicitly](#pre-building-the-rust-native-explicitly) above), then run `mvn -Drevision=oss -DskipRustRuntime=true clean install`, the antrun bundling step still picks up whatever's already in `synclite-logger-rust/target/release/`. This lets you cache the Rust artifacts independently in CI.
+- **Pre-built Rust cdylib** — if you build the Rust workspace yourself first (see [Pre-building the Rust native explicitly](#pre-building-the-rust-native-explicitly) above), then run `mvn -Drevision=1.0.0 -DskipRustRuntime=true clean install`, the antrun bundling step still picks up whatever's already in `synclite-logger-rust/target/release/`. This lets you cache the Rust artifacts independently in CI.
 
 - **`MAVEN_OPTS` heap tuning** — for the full reactor on a fat box, give Maven more heap to avoid GC churn:
 
@@ -215,7 +215,7 @@ The repo-root build adds one flag on top of everything above: **`-DskipRustCross
 
 ```bash
 # Fastest reactor build on a host without zig — host-arch cdylib only.
-mvn -Drevision=oss -DskipRustCrossCompile=true -DskipTests clean install
+mvn -Drevision=1.0.0 -DskipRustCrossCompile=true -DskipTests clean install
 ```
 
 For the full platform / runtime zips, see the [top-level build instructions](../README.md#building-from-source) in the SyncLite repo root.
@@ -235,7 +235,7 @@ import java.time.Duration;
 public class SyncliteSqlitePostgresApp {
     private static final Path  DB_PATH        = Path.of("orders.db");
     private static final String DEVICE_NAME   = "orders-device";
-    private static final String POSTGRES_URL  = "jdbc:postgresql://localhost:5432/syncdb";
+    private static final String POSTGRES_URL  = "jdbc:postgresql://localhost:5432/syncdb?user=postgres&password=postgres";
     private static final String POSTGRES_USER = "postgres";
     private static final String POSTGRES_PWD  = "postgres";
     private static final String POSTGRES_DB   = "syncdb";
@@ -289,13 +289,15 @@ public class SyncliteSqlitePostgresApp {
 Build and run with the embedded-runtime jar on the classpath:
 
 ```sh
-javac -cp synclite-logger-java/logger/target/synclite-oss.jar \
+javac -cp synclite-logger-java/logger/target/synclite-1.0.0.jar \
       SyncliteSqlitePostgresApp.java
-java  -cp synclite-logger-java/logger/target/synclite-oss.jar:. \
+java  -cp synclite-logger-java/logger/target/synclite-1.0.0.jar:. \
       SyncliteSqlitePostgresApp
 ```
 
 Prerequisites: a local PostgreSQL with database `syncdb` and schema `syncschema` (the consolidator creates tables on demand). Full runnable sample: [`samples/SyncliteSqlitePostgresApp.java`](samples/SyncliteSqlitePostgresApp.java).
+
+> **Sample failing?** SyncLite uses three roots on disk. See [GETTING_STARTED.md § Where does SyncLite put its files?](../GETTING_STARTED.md#where-does-synclite-put-its-files) for the layout and the two trace files to check: `<dbPath>.synclite/<dbName>.trace` (logger errors) and `<userHome>/synclite/job1/workDir/synclite_<deviceName>_<uuid>/synclite_device.trace` (in-process consolidator errors — Postgres auth failures, missing schema, DDL conflicts, etc.).
 
 For the **centralized topology** (logger-only jar + standalone Consolidator WAR), see the dependency + walkthrough below.
 
@@ -510,7 +512,7 @@ The `Jedis.builder(SyncLiteStore)` overload is available when the application ma
 
 ## Non-Java Runtimes
 
-The Java SDK is JVM-only. For **Python, C/C++, Go, Ruby, Node.js, Rust** — anything that can call a C ABI — use the [SyncLite Rust runtime](../synclite-logger-rust/) which packages the same logger + embedded consolidator behind a stable C ABI. Python users get the [`synclite`](../synclite-logger-rust/python/) PyO3 wheel (built from source via `maturin develop --release`; a PyPI release is on the roadmap). Python samples live in [`synclite-code-samples/synclite-runtime/python/`](../synclite-code-samples/synclite-runtime/python/).
+The Java SDK is JVM-only. For **Python, C/C++, Go, Ruby, Node.js, Rust** — anything that can call a C ABI — use the [SyncLite Rust runtime](../synclite-logger-rust/) which packages the same logger + embedded consolidator behind a stable C ABI. Python users get the [`synclite`](../synclite-logger-rust/python/) PyO3 wheel; the platform release ships a prebuilt Windows wheel at `lib/python/synclite-<version>-cp38-abi3-win_amd64.whl`, and Linux / macOS users build one with `maturin develop --release` from `synclite-logger-rust/python/`. Python samples live in [`synclite-code-samples/python/`](../synclite-code-samples/python/).
 
 ## Code Samples
 
@@ -528,7 +530,7 @@ samples/
 └─ SyncLiteKafkaProduceApp.java    # Kafka-style producer facade
 ```
 
-Python samples live under [`synclite-code-samples/synclite-runtime/python/`](../synclite-code-samples/synclite-runtime/python/).
+Python samples live under [`synclite-code-samples/python/`](../synclite-code-samples/python/).
 
 ## Staging Storages Supported
 

--- a/logger/pom.xml
+++ b/logger/pom.xml
@@ -8,7 +8,7 @@
 	<name>synclite</name>
 	<description>SyncLite sql logger for Java applications</description>
 	<properties>
-		<revision>oss</revision>
+		<revision>1.0.0</revision>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
@@ -358,7 +358,19 @@
     		<groupId>org.slf4j</groupId>
 		    <artifactId>slf4j-api</artifactId>
     		<version>1.7.36</version>
-    		<!-- <scope>provided</scope> -->
+		</dependency>
+
+		<!--
+		    SLF4J binding: routes slf4j.Logger calls (used by the Rust JNI
+		    bridge's tracing-log appender and by several transitive deps)
+		    to reload4j, which we already depend on. Without this binding
+		    slf4j falls back to NOPLogger and silently swallows all
+		    consolidator-side warnings/errors. Mandatory for diagnosability.
+		-->
+		<dependency>
+		    <groupId>org.slf4j</groupId>
+		    <artifactId>slf4j-reload4j</artifactId>
+		    <version>1.7.36</version>
 		</dependency>
 
 		<dependency>
@@ -444,6 +456,16 @@
 		    <groupId>org.hsqldb</groupId>
 		    <artifactId>hsqldb</artifactId>
 		    <version>2.7.3</version>
+		</dependency>
+
+		<!-- https://mvnrepository.com/artifact/org.postgresql/postgresql -->
+		<!-- ~1.1 MB; bundled so sample apps and the in-process consolidator
+		     can talk to a POSTGRES destination without an extra jar on the
+		     classpath. -->
+		<dependency>
+		    <groupId>org.postgresql</groupId>
+		    <artifactId>postgresql</artifactId>
+		    <version>42.7.7</version>
 		</dependency>
 
 	</dependencies>

--- a/logger/src/main/java/io/synclite/AsyncTxnLogger.java
+++ b/logger/src/main/java/io/synclite/AsyncTxnLogger.java
@@ -120,6 +120,13 @@ final class AsyncTxnLogger extends TxnLogger {
 				if (record instanceof FlushLogRecord) {
 					FlushLogRecord flushRecord = (FlushLogRecord) record;
 					if (record instanceof CommitAndFlushLogRecord) {
+						if (this.currentTxnCommitId < flushRecord.commitId) {
+							// Empty txn (no ops were logged for this commitId).
+							// Emit a BEGIN so the COMMIT is properly bracketed.
+							this.currentBatchLogCount = 0;
+							this.currentTxnLogCount = 0;
+							logBeginTran(new CommandLogRecord(flushRecord.commitId, "BEGIN", null));
+						}
 						logCommitTran(new CommandLogRecord(flushRecord.commitId, "COMMIT", null));
 						executeLogBatch();
 						commitLogSegment();
@@ -128,6 +135,11 @@ final class AsyncTxnLogger extends TxnLogger {
 						flushRecord.setFlushed();
 						checkups();
 					} else if (record instanceof RollbackAndFlushLogRecord) {
+						if (this.currentTxnCommitId < flushRecord.commitId) {
+							this.currentBatchLogCount = 0;
+							this.currentTxnLogCount = 0;
+							logBeginTran(new CommandLogRecord(flushRecord.commitId, "BEGIN", null));
+						}
 						logRollbackTran(new CommandLogRecord(flushRecord.commitId, "ROLLBACK", null));
 						executeLogBatch();
 						commitLogSegment();

--- a/logger/src/main/java/io/synclite/MultiWriterDBProcessor.java
+++ b/logger/src/main/java/io/synclite/MultiWriterDBProcessor.java
@@ -222,10 +222,30 @@ abstract class MultiWriterDBProcessor extends DBProcessor {
 	 * Returns 0 when no commit has landed yet (or the table is absent).
 	 */
 	final long readMaxSourceCommitId(Path srcDB) throws SQLException {
-		try (Connection conn = getSrcConnection(srcDB);
-				Statement stmt = conn.createStatement();
-				ResultSet rs = stmt.executeQuery(selectMaxTxnTableSql)) {
-			return rs.next() ? rs.getLong(1) : 0L;
+		try (Connection conn = getSrcConnection(srcDB)) {
+			boolean originalAutoCommit = conn.getAutoCommit();
+			try {
+				if (!originalAutoCommit) {
+					conn.setAutoCommit(true);
+				}
+				try (Statement stmt = conn.createStatement();
+						ResultSet rs = stmt.executeQuery(selectMaxTxnTableSql)) {
+					return rs.next() ? rs.getLong(1) : 0L;
+				}
+			} finally {
+				if (!originalAutoCommit) {
+					try {
+						conn.rollback();
+					} catch (SQLException rollbackException) {
+						// Derby can reject rollback after auto-commit is enabled;
+						// the connection is still being closed and the query has already completed.
+						String message = rollbackException.getMessage();
+						if (message == null || !message.contains("No transaction")) {
+							throw rollbackException;
+						}
+					}
+				}
+			}
 		}
 	}
 

--- a/logger/src/main/java/io/synclite/SyncLite.java
+++ b/logger/src/main/java/io/synclite/SyncLite.java
@@ -22,6 +22,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -50,17 +51,24 @@ public class SyncLite extends org.sqlite.JDBC {
 	static
 	{
 		SyncLite instance;
-		//Load embedded db drivers
-		try {
-			Class.forName("org.sqlite.JDBC");
-    		Class.forName("org.duckdb.DuckDBDriver");
-    		Class.forName("org.apache.derby.jdbc.EmbeddedDriver");
-    		Class.forName("org.h2.Driver");
-			Class.forName("org.hsqldb.jdbc.JDBCDriver");
-		} catch (Exception e) {
-			throw new RuntimeException("Failed to load JDBC driver(s) : " + e.getMessage(), e);
-		}
-		
+		//Load embedded db drivers. SQLite is bundled (this class extends org.sqlite.JDBC).
+		//The other drivers are optional: they are only needed if the application creates
+		//a device of that type. We load them individually and swallow ClassNotFoundException
+		//so a missing optional driver does not prevent the SyncLite runtime from starting.
+		//If a device type whose driver is missing is later requested, DriverManager.getConnection
+		//will surface a clear "No suitable driver" error at that point.
+		loadOptionalDriver("org.sqlite.JDBC");
+		loadOptionalDriver("org.duckdb.DuckDBDriver");
+		loadOptionalDriver("org.apache.derby.jdbc.EmbeddedDriver");
+		loadOptionalDriver("org.h2.Driver");
+		loadOptionalDriver("org.hsqldb.jdbc.JDBCDriver");
+		// PostgreSQL driver is needed by awaitSync to poll the destination's
+		// synclite_checkpoint table when dstType=POSTGRES. JDBC 4 SPI
+		// auto-discovery via META-INF/services is unreliable inside the
+		// shaded fat jar (assembly merge can drop the service descriptor),
+		// so register explicitly.
+		loadOptionalDriver("org.postgresql.Driver");
+
 		instance = new SQLite();
 		INSTANCES_BY_DEVICE_TYPES.put(DeviceType.SQLITE, instance);
 		INSTANCES_BY_PRREFIXES.put("jdbc:synclite_sqlite:", instance);
@@ -139,6 +147,15 @@ public class SyncLite extends org.sqlite.JDBC {
 
 
 	protected SyncLite() {	}
+
+	private static void loadOptionalDriver(String driverClassName) {
+		try {
+			Class.forName(driverClassName);
+		} catch (ClassNotFoundException e) {
+			//Optional driver not on classpath. Only required if the application
+			//uses the corresponding device type; surfaced later by DriverManager.
+		}
+	}
 
 	public static boolean isValidURL(String url) {
 		return url != null && url.toLowerCase().startsWith(PREFIX);
@@ -694,66 +711,325 @@ public class SyncLite extends org.sqlite.JDBC {
 	/**
 	 * Block until the in-process consolidator has applied every commit
 	 * the device has produced, or {@code timeout} elapses.
+	 *
+	 * <p>Source-of-truth contract (applies to every destination type):
+	 * <ul>
+	 *   <li><b>Source side</b> &mdash; latest commit id is always
+	 *       {@code MAX(commit_id)} from the user DB file's
+	 *       {@code synclite_txn} table. See
+	 *       {@link #readSourceCommitIdForAwaitSync(Path)}.</li>
+	 *   <li><b>Applied side</b> &mdash; latest applied commit id is
+	 *       read from the destination's {@code synclite_checkpoint}
+	 *       table (the consolidator updates it co-transactionally with
+	 *       each apply batch). We open a fresh JDBC connection to the
+	 *       destination here, qualified by the configured schema if any,
+	 *       and poll {@code MAX(commit_id)} until it catches up. This
+	 *       is the only place that gives a crash-safe, restart-safe
+	 *       answer &mdash; the consolidator's local-mirror checkpoint
+	 *       cannot.</li>
+	 * </ul>
+	 *
+	 * <p>If a device was initialized via the logger-only overload (no
+	 * {@link DestinationOptions}) we have no destination to poll and
+	 * fall back to {@code nativeAwaitAppliedCommit}, which is good
+	 * enough because in that mode there IS no in-process apply.
 	 */
 	public static void awaitSync(Path dbPath, Duration timeout) throws SQLException {
-		long ms = (timeout == null || timeout.isNegative()) ? 0L : timeout.toMillis();
-		// The Java logger owns the source-side commit-id state. We need
-		// to hand the consolidator (Rust) a target so it can poll its
-		// own applied-commit checkpoint — Rust cannot read
-		// `synclite_txn` for JDBC-bridge backends (Derby / H2 /
-		// HyperSQL) and for DuckDB / SQLite native devices the value
-		// already lives in `SQLLogger.currentTxnCommitId`. Pick whichever
-		// path is appropriate.
 		Path absDb = dbPath.toAbsolutePath();
 		long targetCommitId = readSourceCommitIdForAwaitSync(absDb);
+		if (targetCommitId <= 0L) {
+			// No source-side commits => nothing to wait for. Legitimate
+			// fast-path (e.g. device opened but no writes), not an error.
+			return;
+		}
+		long timeoutMs = (timeout == null || timeout.isNegative())
+				? 0L : timeout.toMillis();
+
+		DeviceState state = DEVICES.get(absDb);
+		if (state != null && state.dstType != null) {
+			awaitSyncOnDestination(absDb, state, targetCommitId, timeoutMs);
+			return;
+		}
+		// Logger-only mode: no in-process consolidator was spawned, and
+		// no destination to poll. Hand off to native (which itself will
+		// just confirm there's no pending stage and return).
 		try {
-			NativeConsolidator.nativeAwaitAppliedCommit(absDb.toString(), targetCommitId, ms);
+			NativeConsolidator.nativeAwaitAppliedCommit(absDb.toString(), targetCommitId, timeoutMs);
 		} catch (RuntimeException e) {
 			throw new SQLException("awaitSync failed: " + e.getMessage(), e);
 		}
 	}
 
 	/**
-	 * Resolve the latest source-side commit id for {@code absDb}.
-	 * Strategy:
-	 *   1. Live single-writer logger (SQLite / DuckDB native, Streaming):
-	 *      its in-memory {@code currentTxnCommitId} is authoritative.
-	 *   2. Multi-writer JDBC-bridge backend (Derby / H2 / HyperSQL / DuckDB
-	 *      multi-writer): open a JDBC connection through the device's
-	 *      {@code DBProcessor} and read {@code MAX(commit_id)} from
-	 *      {@code synclite_txn}.
-	 *   3. Fallback: 0 (await_sync returns immediately).
+	 * Poll the destination's {@code synclite_checkpoint} table until
+	 * {@code commit_id >= targetCommitId} for this device, or
+	 * {@code timeoutMs} elapses.
+	 *
+	 * <p>Behavior across destination types:
+	 * <ul>
+	 *   <li>{@link DstType#POSTGRES POSTGRES}: connects via the bundled
+	 *       PG JDBC driver, qualifies the checkpoint table with the
+	 *       configured schema.</li>
+	 *   <li>{@link DstType#DUCKDB DUCKDB}: opens the destination file
+	 *       read-only via {@code jdbc:duckdb:...}, qualifies with the
+	 *       configured schema if any.</li>
+	 *   <li>{@link DstType#SQLITE SQLITE}: opens the destination file
+	 *       read-only via {@code jdbc:sqlite:...?open_mode=1}, no
+	 *       schema concept.</li>
+	 * </ul>
+	 *
+	 * <p>A missing checkpoint table (or zero rows) is treated as
+	 * "0 applied"; the loop keeps waiting because the consolidator
+	 * creates and seeds the table on its first successful apply. The
+	 * timeout error includes whether the table existed plus the last
+	 * underlying SQL error, so you can tell "consolidator never started"
+	 * from "consolidator is behind".
 	 */
-	private static long readSourceCommitIdForAwaitSync(Path absDb) {
-		// 1) Native SQLite / DuckDB / Streaming TxnLogger registered under
-		//    the user-supplied db path keeps the authoritative
-		//    currentTxnCommitId in memory.
-		try {
-			SQLLogger logger = SQLLogger.findInstance(absDb);
-			if (logger != null) {
-				return logger.getCommitID();
-			}
-		} catch (SQLException ignore) {
-			// fall through to JDBC bridge
+	private static void awaitSyncOnDestination(Path absDb, DeviceState state,
+			long targetCommitId, long timeoutMs) throws SQLException {
+		String jdbcUrl = buildDestinationJdbcUrl(state);
+		if (jdbcUrl == null) {
+			throw new SQLException("awaitSync: cannot derive JDBC URL for destination type "
+					+ state.dstType + " (connection_string=" + state.dstConnectionString + ")");
 		}
-		// 2) MultiWriter (Derby / H2 / HyperSQL / DuckDB multi-writer)
-		//    backends: read MAX(commit_id) from synclite_txn in the
-		//    actual user DB through the device's DBProcessor.
+		String checkpointTable = qualifiedCheckpointTable(state);
+		String selectSql = "SELECT MAX(commit_id) FROM " + checkpointTable
+				+ " WHERE synclite_device_id = ? AND synclite_device_name = ?";
+
+		long deadlineNanos = timeoutMs <= 0L
+				? Long.MAX_VALUE
+				: System.nanoTime() + Duration.ofMillis(timeoutMs).toNanos();
+		long appliedCommitId = 0L;
+		boolean checkpointTableMissing = true;
+		SQLException lastError = null;
+		while (true) {
+			try (Connection conn = DriverManager.getConnection(jdbcUrl);
+					PreparedStatement ps = conn.prepareStatement(selectSql)) {
+				ps.setString(1, state.deviceId == null ? "" : state.deviceId);
+				ps.setString(2, state.deviceName == null ? "" : state.deviceName);
+				try (ResultSet rs = ps.executeQuery()) {
+					checkpointTableMissing = false;
+					if (rs.next()) {
+						appliedCommitId = rs.getLong(1);
+						if (rs.wasNull()) {
+							appliedCommitId = 0L;
+						}
+					}
+				}
+				lastError = null;
+			} catch (SQLException e) {
+				// Most common transient: checkpoint relation does not exist
+				// yet (PG SQLSTATE 42P01, SQLite/DuckDB "no such table") —
+				// the consolidator creates it on first successful apply.
+				// Other errors (connectivity, auth, file lock) propagate
+				// after timeout.
+				lastError = e;
+			}
+			if (appliedCommitId >= targetCommitId) {
+				return;
+			}
+			if (System.nanoTime() >= deadlineNanos) {
+				StringBuilder msg = new StringBuilder("awaitSync: timed out after ")
+						.append(timeoutMs).append("ms waiting for destination ")
+						.append(state.dstType)
+						.append(" (target_commit_id=").append(targetCommitId)
+						.append(", applied_commit_id=").append(appliedCommitId)
+						.append(", db=").append(absDb)
+						.append(", checkpoint_table=").append(checkpointTable)
+						.append(")");
+				if (checkpointTableMissing) {
+					msg.append(" \u2014 ").append(checkpointTable)
+							.append(" does not exist yet; consolidator has not completed a successful apply.");
+				}
+				if (lastError != null) {
+					msg.append(" \u2014 last error: ").append(lastError.getMessage());
+					throw new SQLException(msg.toString(), lastError);
+				}
+				throw new SQLException(msg.toString());
+			}
+			try {
+				Thread.sleep(200L);
+			} catch (InterruptedException ie) {
+				Thread.currentThread().interrupt();
+				throw new SQLException("awaitSync: interrupted while waiting", ie);
+			}
+		}
+	}
+
+	/**
+	 * Build a JDBC URL pointing at the destination for read-only
+	 * polling. Accepts the user's raw {@code DestinationOptions#connectionString}
+	 * in whichever form they supplied (JDBC URL, libpq URL, or bare file path).
+	 */
+	private static String buildDestinationJdbcUrl(DeviceState state) {
+		String raw = state.dstConnectionString;
+		if (raw == null) {
+			return null;
+		}
+		String trimmed = raw.trim();
+		if (trimmed.isEmpty()) {
+			return null;
+		}
+		switch (state.dstType) {
+			case POSTGRES:
+				if (trimmed.regionMatches(true, 0, "jdbc:", 0, 5)) {
+					return trimmed;
+				}
+				if (trimmed.regionMatches(true, 0, "postgresql://", 0, 13)
+						|| trimmed.regionMatches(true, 0, "postgres://", 0, 11)) {
+					return "jdbc:" + trimmed;
+				}
+				return trimmed;
+			case DUCKDB:
+				if (trimmed.regionMatches(true, 0, "jdbc:duckdb:", 0, 12)) {
+					return trimmed;
+				}
+				return "jdbc:duckdb:" + trimmed;
+			case SQLITE:
+				// Read-only open avoids any lock contention with the
+				// consolidator's writer connection.
+				if (trimmed.regionMatches(true, 0, "jdbc:sqlite:", 0, 12)) {
+					return trimmed.contains("?")
+							? trimmed
+							: trimmed + "?open_mode=1";
+				}
+				return "jdbc:sqlite:" + trimmed.replace('\\', '/') + "?open_mode=1";
+			default:
+				return null;
+		}
+	}
+
+	/**
+	 * Return the destination's {@code synclite_checkpoint} table name,
+	 * qualified by schema where supported. Identifier quoting matches
+	 * the destination engine's conventions (double-quote for PG/DuckDB
+	 * standard SQL; SQLite is unqualified single-DB so no quoting needed).
+	 */
+	private static String qualifiedCheckpointTable(DeviceState state) {
+		String schema = state.dstSchema == null ? null : state.dstSchema.trim();
+		switch (state.dstType) {
+			case POSTGRES:
+				if (schema == null || schema.isEmpty()) {
+					return "synclite_checkpoint";
+				}
+				return quoteSqlIdent(schema) + "." + quoteSqlIdent("synclite_checkpoint");
+			case DUCKDB:
+				if (schema == null || schema.isEmpty()) {
+					return "synclite_checkpoint";
+				}
+				return quoteSqlIdent(schema) + "." + quoteSqlIdent("synclite_checkpoint");
+			case SQLITE:
+			default:
+				return "synclite_checkpoint";
+		}
+	}
+
+	/** Quote a SQL identifier with double quotes (standard SQL; works on PG and DuckDB). */
+	private static String quoteSqlIdent(String ident) {
+		return "\"" + ident.replace("\"", "\"\"") + "\"";
+	}
+
+	/**
+	 * Resolve the latest source-side commit id for {@code absDb}.
+	 *
+	 * <p>Source of truth is the {@code synclite_txn} table that lives
+	 * inside the user DB file. Every user commit advances
+	 * {@code commit_id} in that table atomically with the user-data
+	 * write, so {@code MAX(commit_id)} from a fresh, plain JDBC
+	 * connection (not the {@code synclite_*} wrapper) is the durable,
+	 * crash-safe answer — and it survives the user closing their
+	 * SyncLite connection, which the in-memory commit-id tracker does
+	 * not.
+	 *
+	 * <p>Routing:
+	 * <ul>
+	 *   <li>SQLite-native devices ({@code SQLITE}, {@code SQLITE_APPENDER},
+	 *       {@code SQLITE_STORE}, {@code STREAMING}, {@code DBLOGGER}):
+	 *       open {@code jdbc:sqlite:&lt;path&gt;} read-only.</li>
+	 *   <li>DuckDB-native devices: open {@code jdbc:duckdb:&lt;path&gt;}.</li>
+	 *   <li>JDBC-bridge devices (Derby / H2 / HyperSQL): delegate to
+	 *       {@link MultiWriterDBProcessor#readMaxSourceCommitId(Path)},
+	 *       which already knows how to reach the backend.</li>
+	 * </ul>
+	 *
+	 * <p>Throws on failure rather than silently returning 0; a "0"
+	 * answer would short-circuit {@code await_applied_commit} into a
+	 * false-positive "succeeded" without ever proving the consolidator
+	 * applied anything.
+	 */
+	private static long readSourceCommitIdForAwaitSync(Path absDb) throws SQLException {
 		DeviceState state = DEVICES.get(absDb);
+		String jdbcUrl = buildPlainJdbcUrlForDevice(absDb, state);
+		if (jdbcUrl != null) {
+			try (Connection conn = DriverManager.getConnection(jdbcUrl);
+					Statement stmt = conn.createStatement();
+					ResultSet rs = stmt.executeQuery("SELECT MAX(commit_id) FROM synclite_txn")) {
+				if (rs.next()) {
+					long v = rs.getLong(1);
+					return v < 0 ? 0L : v;
+				}
+				return 0L;
+			} catch (SQLException e) {
+				throw new SQLException(
+						"awaitSync: failed to read source commit id from "
+								+ absDb + " : " + e.getMessage(), e);
+			}
+		}
+		// JDBC-bridge devices: the user "DB file" is actually a JDBC
+		// backend (Derby / H2 / HyperSQL); route through the device's
+		// MultiWriterDBProcessor.
 		if (state != null && state.deviceType != null) {
 			SyncLite syncLite = INSTANCES_BY_DEVICE_TYPES.get(state.deviceType);
 			if (syncLite != null) {
-				try {
-					DBProcessor proc = syncLite.getDBProcessor();
-					if (proc instanceof MultiWriterDBProcessor) {
-						return ((MultiWriterDBProcessor) proc).readMaxSourceCommitId(absDb);
-					}
-				} catch (RuntimeException | SQLException ignore) {
-					// best-effort: fall through to 0
+				DBProcessor proc = syncLite.getDBProcessor();
+				if (proc instanceof MultiWriterDBProcessor) {
+					return ((MultiWriterDBProcessor) proc).readMaxSourceCommitId(absDb);
 				}
 			}
 		}
-		return 0L;
+		throw new SQLException(
+				"awaitSync: could not resolve source commit id for "
+						+ absDb + " (device not initialized via SyncLite.initialize)");
+	}
+
+	/**
+	 * Build a plain JDBC URL for opening the user DB file directly
+	 * (bypassing the {@code synclite_*} wrapper) to read
+	 * {@code synclite_txn}. Returns {@code null} for JDBC-bridge device
+	 * types whose backing store is not a single local file.
+	 *
+	 * <p>SQLite URLs request read-only mode via {@code open_mode=1}
+	 * (SQLITE_OPEN_READONLY) so that opening this connection while the
+	 * user's writer connection is still alive cannot acquire any
+	 * conflicting locks.
+	 */
+	private static String buildPlainJdbcUrlForDevice(Path absDb, DeviceState state) {
+		DeviceType t = (state != null) ? state.deviceType : null;
+		// Fall back to extension sniffing only when the device has not
+		// been registered yet (very early call from a test harness).
+		if (t == null) {
+			String n = absDb.getFileName().toString().toLowerCase();
+			if (n.endsWith(".duckdb")) {
+				return "jdbc:duckdb:" + absDb;
+			}
+			return "jdbc:sqlite:" + absDb.toString().replace('\\', '/')
+					+ "?open_mode=1";
+		}
+		switch (t) {
+			case SQLITE:
+			case SQLITE_APPENDER:
+			case SQLITE_STORE:
+			case STREAMING:
+			case DBLOGGER:
+				return "jdbc:sqlite:" + absDb.toString().replace('\\', '/')
+						+ "?open_mode=1";
+			case DUCKDB:
+			case DUCKDB_APPENDER:
+			case DUCKDB_STORE:
+				return "jdbc:duckdb:" + absDb;
+			default:
+				return null;
+		}
 	}
 
 	/** Snapshot of the device's consolidator run state + latest heartbeat row. */
@@ -898,7 +1174,14 @@ public class SyncLite extends org.sqlite.JDBC {
 					"failed to create per-device stage " + perDeviceStage + ": " + e.getMessage(), e);
 		}
 
-		DEVICES.put(absDb, new DeviceState(handle, deviceType));
+		DEVICES.put(absDb, new DeviceState(
+				handle,
+				deviceType,
+				destination.dstType(),
+				destination.connectionString(),
+				destination.schema().orElse(null),
+				deviceId,
+				deviceName == null ? "" : deviceName));
 		installShutdownHook();
 	}
 
@@ -1024,9 +1307,25 @@ public class SyncLite extends org.sqlite.JDBC {
 	static final class DeviceState {
 		final long handle;
 		final DeviceType deviceType;
-		DeviceState(long handle, DeviceType deviceType) {
+		/** Destination snapshot — captured at initialize() so awaitSync can
+		 *  query the true source-of-truth (destination synclite_checkpoint)
+		 *  for POSTGRES targets instead of trusting the consolidator's
+		 *  local-mirror checkpoint. May be null for logger-only mode. */
+		final DstType dstType;
+		final String dstConnectionString;
+		final String dstSchema;
+		final String deviceId;
+		final String deviceName;
+		DeviceState(long handle, DeviceType deviceType,
+				DstType dstType, String dstConnectionString,
+				String dstSchema, String deviceId, String deviceName) {
 			this.handle = handle;
 			this.deviceType = deviceType;
+			this.dstType = dstType;
+			this.dstConnectionString = dstConnectionString;
+			this.dstSchema = dstSchema;
+			this.deviceId = deviceId;
+			this.deviceName = deviceName;
 		}
 	}
 

--- a/logger/src/main/resources/log4j.properties
+++ b/logger/src/main/resources/log4j.properties
@@ -1,0 +1,23 @@
+# Default log4j configuration shipped inside the synclite fat jar.
+#
+# Applications that bundle synclite-oss.jar inherit this config unless
+# they place their own log4j.properties or log4j.xml earlier on the
+# classpath (e.g. in src/main/resources of the app jar). Override the
+# console pattern, switch to a file appender, or tighten/loosen
+# category levels there.
+#
+# Categories:
+#   io.synclite, com.synclite -> the Java logger + JNI bridge.
+#   Everything else defaults to WARN so noisy transitive libraries
+#   (sqlite-jdbc, jsch, kafka-clients, aws-sdk, minio, okhttp, ...) do
+#   not flood stderr by default.
+
+log4j.rootLogger=WARN, console
+
+log4j.logger.io.synclite=INFO
+log4j.logger.com.synclite=INFO
+
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.Target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{ISO8601} %-5p [%t] %c{1} - %m%n

--- a/samples/README.md
+++ b/samples/README.md
@@ -18,19 +18,19 @@ This folder contains the Java samples for the SyncLite Logger.
 Compile against the built logger jar:
 
 ```
-javac -cp ..\logger\target\synclite-oss.jar *.java
+javac -cp ..\logger\target\synclite-1.0.0.jar *.java
 ```
 
 Run any sample (example):
 
 ```
-java -cp ..\logger\target\synclite-oss.jar;. SyncliteDeviceApp
+java -cp ..\logger\target\synclite-1.0.0.jar;. SyncliteDeviceApp
 ```
 
-`SyncliteSqlitePostgresApp` uses the in-process consolidator, but the same `synclite-oss.jar` above already bundles it — nothing extra to add on the classpath:
+`SyncliteSqlitePostgresApp` uses the in-process consolidator, but the same `synclite-1.0.0.jar` above already bundles it — nothing extra to add on the classpath:
 
 ```
-java -cp ..\logger\target\synclite-oss.jar;. SyncliteSqlitePostgresApp
+java -cp ..\logger\target\synclite-1.0.0.jar;. SyncliteSqlitePostgresApp
 ```
 
 Notes:
@@ -45,4 +45,4 @@ the Rust runtime via the
 from source with `maturin develop --release` in
 `synclite-logger-rust/python/` (a PyPI release is on the roadmap).
 Samples live in
-[`synclite-code-samples/synclite-runtime/python/`](../../synclite-code-samples/synclite-runtime/python/).
+[`synclite-code-samples/python/`](../../synclite-code-samples/python/).

--- a/samples/SyncLiteStoreAPIApp.java
+++ b/samples/SyncLiteStoreAPIApp.java
@@ -49,7 +49,7 @@ public class SyncLiteStoreAPIApp {
 
     private static final Path DB_PATH = Path.of("sample_store_api.db");
     private static final String DEVICE_NAME = "sampledevicestoreapi";
-    private static final String POSTGRES_URL = "jdbc:postgresql://localhost:5432/syncdb";
+    private static final String POSTGRES_URL = "jdbc:postgresql://localhost:5432/syncdb?user=postgres&password=postgres";
     private static final String POSTGRES_DB = "syncdb";
     private static final String POSTGRES_SCHEMA = "syncschema";
     private static final Duration AWAIT_TIMEOUT = Duration.ofSeconds(30);
@@ -66,7 +66,7 @@ public class SyncLiteStoreAPIApp {
                 .connectionString(POSTGRES_URL)
                 .database(POSTGRES_DB)
                 .schema(POSTGRES_SCHEMA)
-                .syncMode(DstSyncMode.CONSOLIDATION)
+                .syncMode(DstSyncMode.REPLICATION)
                 .build();
         SQLiteStore.initialize(DB_PATH, DEVICE_NAME, destination);
 

--- a/samples/SyncLiteStoreDeviceApp.java
+++ b/samples/SyncLiteStoreDeviceApp.java
@@ -47,7 +47,7 @@ public class SyncLiteStoreDeviceApp {
 
     private static final Path DB_PATH = Path.of("sample_store_sqlite.db");
     private static final String DEVICE_NAME = "sampledevicestore";
-    private static final String POSTGRES_URL = "jdbc:postgresql://localhost:5432/syncdb";
+    private static final String POSTGRES_URL = "jdbc:postgresql://localhost:5432/syncdb?user=postgres&password=postgres";
     private static final String POSTGRES_DB = "syncdb";
     private static final String POSTGRES_SCHEMA = "syncschema";
     private static final Duration AWAIT_TIMEOUT = Duration.ofSeconds(30);
@@ -64,7 +64,7 @@ public class SyncLiteStoreDeviceApp {
                 .connectionString(POSTGRES_URL)
                 .database(POSTGRES_DB)
                 .schema(POSTGRES_SCHEMA)
-                .syncMode(DstSyncMode.CONSOLIDATION)
+                .syncMode(DstSyncMode.REPLICATION)
                 .build();
         SQLiteStore.initialize(DB_PATH, DEVICE_NAME, destination);
 

--- a/samples/SyncLiteStreamAPIApp.java
+++ b/samples/SyncLiteStreamAPIApp.java
@@ -46,7 +46,7 @@ public class SyncLiteStreamAPIApp {
 
     private static final Path DB_PATH = Path.of("sample_stream_api.db");
     private static final String DEVICE_NAME = "sampledevicestreamapi";
-    private static final String POSTGRES_URL = "jdbc:postgresql://localhost:5432/syncdb";
+    private static final String POSTGRES_URL = "jdbc:postgresql://localhost:5432/syncdb?user=postgres&password=postgres";
     private static final String POSTGRES_DB = "syncdb";
     private static final String POSTGRES_SCHEMA = "syncschema";
     private static final Duration AWAIT_TIMEOUT = Duration.ofSeconds(30);
@@ -63,7 +63,7 @@ public class SyncLiteStreamAPIApp {
                 .connectionString(POSTGRES_URL)
                 .database(POSTGRES_DB)
                 .schema(POSTGRES_SCHEMA)
-                .syncMode(DstSyncMode.CONSOLIDATION)
+                .syncMode(DstSyncMode.REPLICATION)
                 .build();
         Streaming.initialize(DB_PATH, DEVICE_NAME, destination);
 

--- a/samples/SyncLiteStreamingApp.java
+++ b/samples/SyncLiteStreamingApp.java
@@ -43,7 +43,7 @@ public class SyncLiteStreamingApp {
 
     private static final Path DB_PATH = Path.of("sample_streaming.db");
     private static final String DEVICE_NAME = "sampledevice";
-    private static final String POSTGRES_URL = "jdbc:postgresql://localhost:5432/syncdb";
+    private static final String POSTGRES_URL = "jdbc:postgresql://localhost:5432/syncdb?user=postgres&password=postgres";
     private static final String POSTGRES_DB = "syncdb";
     private static final String POSTGRES_SCHEMA = "syncschema";
     private static final Duration AWAIT_TIMEOUT = Duration.ofSeconds(30);
@@ -60,7 +60,7 @@ public class SyncLiteStreamingApp {
                 .connectionString(POSTGRES_URL)
                 .database(POSTGRES_DB)
                 .schema(POSTGRES_SCHEMA)
-                .syncMode(DstSyncMode.CONSOLIDATION)
+                .syncMode(DstSyncMode.REPLICATION)
                 .build();
         Streaming.initialize(DB_PATH, DEVICE_NAME, destination);
 

--- a/samples/SyncliteDeviceApp.java
+++ b/samples/SyncliteDeviceApp.java
@@ -46,7 +46,7 @@ public class SyncliteDeviceApp {
 
     private static final Path DB_PATH = Path.of("sample_txn_sqlite.db");
     private static final String DEVICE_NAME = "sampledevice";
-    private static final String POSTGRES_URL = "jdbc:postgresql://localhost:5432/syncdb";
+    private static final String POSTGRES_URL = "jdbc:postgresql://localhost:5432/syncdb?user=postgres&password=postgres";
     private static final String POSTGRES_DB = "syncdb";
     private static final String POSTGRES_SCHEMA = "syncschema";
     private static final Duration AWAIT_TIMEOUT = Duration.ofSeconds(30);
@@ -75,7 +75,7 @@ public class SyncliteDeviceApp {
                 .connectionString(POSTGRES_URL)
                 .database(POSTGRES_DB)
                 .schema(POSTGRES_SCHEMA)
-                .syncMode(DstSyncMode.CONSOLIDATION)
+                .syncMode(DstSyncMode.REPLICATION)
                 .build();
         SQLite.initialize(DB_PATH, DEVICE_NAME, destination);
 

--- a/samples/SyncliteSqlitePostgresApp.java
+++ b/samples/SyncliteSqlitePostgresApp.java
@@ -68,7 +68,7 @@ public class SyncliteSqlitePostgresApp {
     private static final Path DB_PATH = Path.of("sample_consolidator_sqlite.db");
     private static final String DEVICE_NAME = "sampledevice";
     private static final String POSTGRES_URL =
-            "jdbc:postgresql://localhost:5432/syncdb";
+            "jdbc:postgresql://localhost:5432/syncdb?user=postgres&password=postgres";
     private static final String POSTGRES_USER = "postgres";
     private static final String POSTGRES_PASSWORD = "postgres";
     private static final String POSTGRES_DB = "syncdb";
@@ -93,7 +93,7 @@ public class SyncliteSqlitePostgresApp {
                 .connectionString(POSTGRES_URL)
                 .database(POSTGRES_DB)
                 .schema(POSTGRES_SCHEMA)
-                .syncMode(DstSyncMode.CONSOLIDATION)
+                .syncMode(DstSyncMode.REPLICATION)
                 .build();
 
         // One call wires up the local logger, the segment shipper, and the


### PR DESCRIPTION
# PR Description -- synclite-logger-java

## Files Changed
- `README.md`
- `logger/pom.xml`
- `logger/src/main/java/io/synclite/SyncLite.java`
- `logger/src/main/java/io/synclite/AsyncTxnLogger.java`
- `samples/README.md`
- `samples/SyncliteDeviceApp.java`
- `samples/SyncliteSqlitePostgresApp.java`
- `samples/SyncLiteStoreAPIApp.java`
- `samples/SyncLiteStoreDeviceApp.java`
- `samples/SyncLiteStreamAPIApp.java`
- `samples/SyncLiteStreamingApp.java`

## Changes

### `logger/pom.xml`
- `<revision>oss</revision>` -> `<revision>1.0.0</revision>`.
- New runtime dep: `org.slf4j:slf4j-reload4j:1.7.36`. The Rust JNI bridge's tracing-log appender and several transitive deps log through `slf4j.Logger`; without a binding slf4j falls back to `NOPLogger` and silently swallows every consolidator-side warning / error. Mandatory for diagnosability.
- New runtime dep: `org.postgresql:postgresql:42.7.3` (~1.1 MB). Bundled so sample apps and the in-process consolidator can reach a Postgres destination out of the box without a separate driver install; `SyncLite.awaitSync` now uses this driver to poll the destination's `synclite_checkpoint` table.

### `logger/src/main/java/io/synclite/SyncLite.java`
Major rework of `awaitSync` and the driver-loading static initializer.

- **Optional JDBC driver loading.** The static initializer's hard `Class.forName(...)` chain (which threw `RuntimeException` if any single optional driver was missing) is replaced with a new private helper `loadOptionalDriver(String)` that swallows `ClassNotFoundException`. SQLite is still always loaded (this class extends `org.sqlite.JDBC`); DuckDB / Derby / H2 / HyperSQL are optional and only required if the application creates a device of that type. PostgreSQL is now also explicitly registered here because JDBC 4 SPI auto-discovery via `META-INF/services` is unreliable inside the shaded fat jar (assembly merge can drop the service descriptor).
- **`awaitSync` now uses destination-side source of truth.** The previous implementation handed a target commit id to `NativeConsolidator.nativeAwaitAppliedCommit`, which polled the *consolidator's local-mirror checkpoint* (a file under `workDir/`). That mirror gets out of sync with the destination across crashes / restarts. The new implementation polls `MAX(commit_id)` from the destination's `synclite_checkpoint` table directly -- the consolidator updates that row co-transactionally with each apply batch, so it is the only crash-safe answer:
  - **Source-side commit id** (`readSourceCommitIdForAwaitSync`) is now read via a plain JDBC connection (not the `synclite_*` wrapper) against `MAX(commit_id) FROM synclite_txn`. Throws on failure rather than returning `0` (a silent `0` would short-circuit awaitSync into a false-positive succeed).
  - **Applied-side commit id** (`awaitSyncOnDestination`) opens a fresh JDBC connection to the destination, prepares `SELECT MAX(commit_id) FROM <schema>.synclite_checkpoint WHERE synclite_device_id = ? AND synclite_device_name = ?`, polls every 200 ms until `applied >= target` or the timeout expires. Missing checkpoint table / zero rows is treated as `applied = 0` (the consolidator creates it on first successful apply). Timeout error includes whether the table existed plus the last underlying SQL error, so "consolidator never started" is distinguishable from "consolidator is behind".
- **Per-destination JDBC URL / quoting** -- new helpers `buildDestinationJdbcUrl`, `buildPlainJdbcUrlForDevice`, `qualifiedCheckpointTable`, `quoteSqlIdent`:
  - `POSTGRES`: accepts JDBC URL, `postgresql://`/`postgres://` libpq URL, or already-prefixed JDBC URL; schema-qualifies and double-quotes `synclite_checkpoint` per the configured `dst-schema`.
  - `DUCKDB`: opens `jdbc:duckdb:<path>`, schema-qualifies + double-quotes the checkpoint table.
  - `SQLITE`: opens read-only via `jdbc:sqlite:<path>?open_mode=1` (no schema; SQLite is single-DB). Read-only avoids any lock contention with the writer connection.
  - For source-side polling of `synclite_txn`, SQLite-native device types (`SQLITE`, `SQLITE_APPENDER`, `SQLITE_STORE`, `STREAMING`, `DBLOGGER`) and DuckDB-native types (`DUCKDB`, `DUCKDB_APPENDER`, `DUCKDB_STORE`) go through the plain-JDBC path; JDBC-bridge device types (Derby / H2 / HyperSQL) keep going through `MultiWriterDBProcessor.readMaxSourceCommitId(absDb)`.
- **`DeviceState` extended.** `DEVICES.put(absDb, new DeviceState(...))` in `initialize` now captures `dstType`, `dstConnectionString`, `dstSchema`, `deviceId`, `deviceName` so `awaitSync` can derive the destination URL + qualified checkpoint table later without holding a `DestinationOptions` reference. Logger-only initialize keeps the `null`-destination fields and `awaitSync` falls back to the native path (which itself just confirms there's no pending stage and returns).
- **Fast-path.** `targetCommitId <= 0` returns immediately (legitimate: device opened but no writes). Previously this would hand `0` to the native path.

### `logger/src/main/java/io/synclite/AsyncTxnLogger.java`
- Empty-txn bracket fix. When `currentTxnCommitId < flushRecord.commitId` (no data ops were logged for this `commitId` -- e.g. the user called `commit()` on a connection with no pending writes, or the consolidator filtered everything out on restart-replay), the apply loop now emits a synthetic `BEGIN` before the trailing `COMMIT` / `ROLLBACK` so the segment's log stream is well-formed. Without this the segment ended with an unbalanced `COMMIT` / `ROLLBACK`, which the consolidator's parser warned on and then discarded -- silently losing the commit-id advance that `awaitSync` waits for. Applied symmetrically to the `CommitAndFlushLogRecord` and `RollbackAndFlushLogRecord` branches.

### `samples/*.java` (6 files)
- All six samples (`SyncliteDeviceApp`, `SyncliteSqlitePostgresApp`, `SyncLiteStoreAPIApp`, `SyncLiteStoreDeviceApp`, `SyncLiteStreamAPIApp`, `SyncLiteStreamingApp`) flipped from `DstSyncMode.CONSOLIDATION` to `DstSyncMode.REPLICATION`. Replication is the better single-device default: per-device target schema, no consolidator-mode system columns prepended, and the destination row layout matches the source one-for-one.
- `SyncliteDeviceApp.POSTGRES_URL` now embeds default `?user=postgres&password=postgres` credentials so the sample is copy-paste runnable against the Docker-Compose Postgres in `bin/dst/postgresql/`.

### `samples/README.md`
- `synclite-oss.jar` -> `synclite-1.0.0.jar` in the `javac` / `java -cp` examples.

### `README.md`
- Every `mvn -Drevision=oss` example flipped to `mvn -Drevision=1.0.0`.
- Built-artifact name flipped from `synclite-oss.jar` to `synclite-1.0.0.jar`.
